### PR TITLE
Remove httpd dependency from php-fpm Dockerfile

### DIFF
--- a/images/httpd/Dockerfile
+++ b/images/httpd/Dockerfile
@@ -2,5 +2,3 @@
 FROM httpd:2.4
 
 COPY ./usr/local/apache2/conf/httpd.conf /usr/local/apache2/conf/httpd.conf
-
-RUN ln -s /srv/vanilla-repositories/vanilla /srv/htdocs

--- a/images/httpd/usr/local/apache2/conf/httpd.conf
+++ b/images/httpd/usr/local/apache2/conf/httpd.conf
@@ -44,8 +44,8 @@ LoadModule ssl_module modules/mod_ssl.so
 </Directory>
 
 # Base host configuration
-DocumentRoot "/srv/htdocs"
-<Directory "/srv/htdocs">
+DocumentRoot "/srv/vanilla-repositories/vanilla"
+<Directory "/srv/vanilla-repositories/vanilla">
     Options Indexes FollowSymLinks
     AllowOverride All
     Require all granted

--- a/images/php-fpm/Dockerfile
+++ b/images/php-fpm/Dockerfile
@@ -22,7 +22,6 @@ COPY ./usr/local/etc/php/conf.d/10-xdebug.ini /usr/local/etc/php/conf.d/10-xdebu
 COPY ./usr/local/etc/php/conf.d/vanilla-docker-sendmail.ini /usr/local/etc/php/conf.d/vanilla-docker-sendmail.ini
 
 RUN mkdir -p /shared/var/run/
-RUN ln -s /srv/vanilla-repositories/vanilla /srv/htdocs
 
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 


### PR DESCRIPTION
From: https://wiki.apache.org/httpd/PHP-FPM
> /path/to/your/documentroot/
IMPORTANT! This must exactly match the real filesystem location of your php files, because that is where the php-fpm daemon will look for them.
php-fpm just interprets the php files passed to it; it is not a web server, nor does it understand your web servers' namespace, virtualhost layout, or aliases.
IMPORTANT! Read the above again

Since the realpath in the php-fpm container is "srv/vanilla-repositories/vanilla" we need to use that path in httpd.conf
All vhosts will have to do the same.