### PR TITLE
Allow sso.vanilla.localhost to be resolved from the php container.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,10 @@ services:
             - "FASTCGI_BUFFERS=${VANILLA_DOCKER_FASTCGI_BUFFERS}"
             - "FASTCGI_BUSY_BUFFERS_SIZE=${VANILLA_DOCKER_FASTCGI_BUSY_BUFFERS_SIZE}"
             - "FASTCGI_TEMP_FILE_WRITE_SIZE=${VANILLA_DOCKER_FASTCGI_TEMP_FILE_WRITE_SIZE}"
+        networks:
+            default:
+                aliases:
+                    - "sso.vanilla.localhost" # Allows sso.vanilla.localhost to be resolved internally from php-fpm
         ports:
             - "80:80"
             - "8080:8080"
@@ -64,6 +68,7 @@ services:
         volumes:
             - "shared:/shared" # expose php-fpm socket
             - "./logs/php-fpm:/var/log/php-fpm"
+            - "./resources/certificates:/usr/local/share/ca-certificates" # Mount extra certificates
             - "./resources/usr/local/etc/php/conf.d:/usr/local/etc/php/custom.conf.d"
             - "../:/srv/vanilla-repositories"
 

--- a/images/php-fpm/docker-entrypoint.sh
+++ b/images/php-fpm/docker-entrypoint.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
-configured=$(grep 'noreply@dev.vanilla.localhost' /etc/hosts)
-if [ -z "$configured" ]; then
+# Configure sendmail
+sendmailConfigured=$(grep 'noreply@dev.vanilla.localhost' /etc/hosts)
+if [ -z "$sendmailConfigured" ]; then
     # add host to /etc/hosts
     host=$(hostname)
     line=$(cat /etc/hosts | grep $host)
@@ -24,6 +25,9 @@ fi
 
 # Start sendmail
 sendmail -bd
+
+# Reload certificates so that everything in /usr/local/share/ca-certificates is loaded.
+update-ca-certificates
 
 # Start php-fpm
 php-fpm


### PR DESCRIPTION
This is needed by [OAuth2](https://github.com/vanilla/stub-sso-providers/pull/6) that does a server call to /oauth2/access_token.
Also add vanilla.localhost.crt to the php container' Certificate Authority. Otherwise CURL would throw an error about the certificate being self signed.