### PR TITLE
Add support for stub-embed-providers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ custom.*.yml
 !/resources/etc/nginx/sites-available/sso.vanilla.localhost.conf
 !/resources/etc/nginx/sites-available/dev.vanilla.localhost.conf
 !/resources/etc/nginx/sites-available/vanilla.test.conf
+!/resources/etc/nginx/sites-available/embed.vanilla.localhost.conf
+!/resources/etc/nginx/sites-available/advanced-embed.vanilla.localhost.conf
 !/resources/usr/local/apache2/conf.d/vanilla.localhost.ssl.conf
 !/resources/usr/local/etc/sphinx/conf.d/configs-available/advanced.sphinx.conf
 !/resources/usr/local/etc/sphinx/conf.d/configs-available/standard.sphinx.conf

--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ nginx web server
 
 - Serve:
     - https://dev.vanilla.localhost (main forum)
-    - https://sso.vanilla.localhost (sso providers)
+    - https://sso.vanilla.localhost ([stub-sso-providers](https://github.com/vanilla/stub-sso-providers))
+    - https://embed.vanilla.localhost ([stub-embed-providers](https://github.com/vanilla/stub-embed-providers))
+    - https://advanced-embed.vanilla.localhost ([stub-embed-providers](https://github.com/vanilla/stub-embed-providers))
     - http://vanilla.test:8080 (unit tests address)
 
 ### php-fpm

--- a/images/nginx/Dockerfile
+++ b/images/nginx/Dockerfile
@@ -6,3 +6,4 @@ COPY ./etc/nginx/fastcgi.conf.tpl /etc/nginx/fastcgi.conf.tpl
 
 RUN ln -s /srv/vanilla-repositories/vanilla /srv/htdocs
 RUN ln -s /srv/vanilla-repositories/stub-sso-providers /srv/sso
+RUN ln -s /srv/vanilla-repositories/stub-embed-providers /srv/embed

--- a/mac-setup.sh
+++ b/mac-setup.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-HOSTNAMES=(database dev.vanilla.localhost sso.vanilla.localhost vanilla.test);
+HOSTNAMES=(database dev.vanilla.localhost sso.vanilla.localhost vanilla.test embed.vanilla.localhost advanced-embed.vanilla.localhost);
 
 if [[ $UID != 0 ]]; then
     echo "Please run this script with sudo:";

--- a/resources/etc/nginx/sites-available/advanced-embed.vanilla.localhost.conf
+++ b/resources/etc/nginx/sites-available/advanced-embed.vanilla.localhost.conf
@@ -1,0 +1,24 @@
+server {
+
+    server_name advanced-embed.vanilla.localhost;
+    listen 80;
+
+    listen 443 ssl;
+    ssl_certificate      /certificates/vanilla.localhost.crt;
+    ssl_certificate_key  /certificates/vanilla.localhost.key;
+
+    root /srv/embed/advanced;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ @htmlext;
+    }
+
+    location ~ \.html$ {
+        try_files $uri =404;
+    }
+
+    location @htmlext {
+        rewrite ^(.*)$ $1.html last;
+    }
+}

--- a/resources/etc/nginx/sites-available/embed.vanilla.localhost.conf
+++ b/resources/etc/nginx/sites-available/embed.vanilla.localhost.conf
@@ -1,0 +1,24 @@
+server {
+
+    server_name embed.vanilla.localhost;
+    listen 80;
+
+    listen 443 ssl;
+    ssl_certificate      /certificates/vanilla.localhost.crt;
+    ssl_certificate_key  /certificates/vanilla.localhost.key;
+
+    root /srv/embed/simple;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ @htmlext;
+    }
+
+    location ~ \.html$ {
+        try_files $uri =404;
+    }
+
+    location @htmlext {
+        rewrite ^(.*)$ $1.html last;
+    }
+}

--- a/resources/etc/nginx/sites-enabled/advanced-embed.vanilla.localhost.conf
+++ b/resources/etc/nginx/sites-enabled/advanced-embed.vanilla.localhost.conf
@@ -1,0 +1,1 @@
+../sites-available/advanced-embed.vanilla.localhost.conf

--- a/resources/etc/nginx/sites-enabled/embed.vanilla.localhost.conf
+++ b/resources/etc/nginx/sites-enabled/embed.vanilla.localhost.conf
@@ -1,0 +1,1 @@
+../sites-available/embed.vanilla.localhost.conf


### PR DESCRIPTION
Closes #18 

Similar to stub-sso-providers, stub-embed-providers gives a simple embed implementation to vanilla-docker for testing.

Goes with https://github.com/vanilla/stub-embed-providers/pull/1