### PR TITLE
Improve path mapping by removing internal symlinks

### DIFF
--- a/images/nginx/Dockerfile
+++ b/images/nginx/Dockerfile
@@ -3,7 +3,3 @@ FROM nginx:1.13
 
 COPY ./etc/nginx/nginx.conf /etc/nginx/nginx.conf
 COPY ./etc/nginx/fastcgi.conf.tpl /etc/nginx/fastcgi.conf.tpl
-
-RUN ln -s /srv/vanilla-repositories/vanilla /srv/htdocs
-RUN ln -s /srv/vanilla-repositories/stub-sso-providers /srv/sso
-RUN ln -s /srv/vanilla-repositories/stub-embed-providers /srv/embed

--- a/images/php-fpm/Dockerfile
+++ b/images/php-fpm/Dockerfile
@@ -23,7 +23,6 @@ COPY ./usr/local/etc/php/conf.d/00-php.ini /usr/local/etc/php/conf.d/00-php.ini
 COPY ./usr/local/etc/php/conf.d/10-xdebug.ini /usr/local/etc/php/conf.d/10-xdebug.ini
 COPY ./usr/local/etc/php/conf.d/vanilla-docker-sendmail.ini /usr/local/etc/php/conf.d/vanilla-docker-sendmail.ini
 
-RUN ln -s /srv/vanilla-repositories/vanilla /srv/htdocs
 RUN mkdir -p /shared/var/run/
 
 COPY docker-entrypoint.sh /docker-entrypoint.sh

--- a/resources/etc/nginx/sites-available/advanced-embed.vanilla.localhost.conf
+++ b/resources/etc/nginx/sites-available/advanced-embed.vanilla.localhost.conf
@@ -7,7 +7,7 @@ server {
     ssl_certificate      /certificates/vanilla.localhost.crt;
     ssl_certificate_key  /certificates/vanilla.localhost.key;
 
-    root /srv/embed/advanced;
+    root /srv/vanilla-repositories/stub-embed-providers/advanced;
     index index.html;
 
     location / {

--- a/resources/etc/nginx/sites-available/dev.vanilla.localhost.conf
+++ b/resources/etc/nginx/sites-available/dev.vanilla.localhost.conf
@@ -3,7 +3,7 @@ server {
     server_name dev.vanilla.localhost;
     listen 80 default_server;
 
-    listen 443 ssl;
+    listen 443 default_server ssl;
     ssl_certificate      /certificates/vanilla.localhost.crt;
     ssl_certificate_key  /certificates/vanilla.localhost.key;
 

--- a/resources/etc/nginx/sites-available/dev.vanilla.localhost.conf
+++ b/resources/etc/nginx/sites-available/dev.vanilla.localhost.conf
@@ -7,7 +7,7 @@ server {
     ssl_certificate      /certificates/vanilla.localhost.crt;
     ssl_certificate_key  /certificates/vanilla.localhost.key;
 
-    root /srv/htdocs;
+    root /srv/vanilla-repositories/vanilla;
     index index.php;
 
     # Hardening

--- a/resources/etc/nginx/sites-available/embed.vanilla.localhost.conf
+++ b/resources/etc/nginx/sites-available/embed.vanilla.localhost.conf
@@ -7,7 +7,7 @@ server {
     ssl_certificate      /certificates/vanilla.localhost.crt;
     ssl_certificate_key  /certificates/vanilla.localhost.key;
 
-    root /srv/embed/simple;
+    root /srv/vanilla-repositories/stub-embed-providers/simple;
     index index.html;
 
     location / {

--- a/resources/etc/nginx/sites-available/sso.vanilla.localhost.conf
+++ b/resources/etc/nginx/sites-available/sso.vanilla.localhost.conf
@@ -7,7 +7,7 @@ server {
     ssl_certificate      /certificates/vanilla.localhost.crt;
     ssl_certificate_key  /certificates/vanilla.localhost.key;
 
-    root /srv/sso;
+    root /srv/vanilla-repositories/stub-sso-providers;
     index index.php;
 
     location ^~ "/favicon.ico" { access_log off; log_not_found off; return 404; }

--- a/resources/etc/nginx/sites-available/vanilla.test.conf
+++ b/resources/etc/nginx/sites-available/vanilla.test.conf
@@ -4,7 +4,7 @@ server {
     server_name vanilla.test;
     listen 8080;
 
-    root /srv/htdocs;
+    root /srv/vanilla-repositories/vanilla;
     index index.php;
 
     location ^~ "/favicon.ico" { access_log off; log_not_found off; return 404; }

--- a/resources/usr/local/apache2/conf.d/vanilla.localhost.ssl.conf
+++ b/resources/usr/local/apache2/conf.d/vanilla.localhost.ssl.conf
@@ -6,7 +6,7 @@
     SSLCertificateFile /certificates/vanilla.localhost.crt
     SetEnvIf User-Agent ".*MSIE.*" nokeepalive ssl-unclean-shutdown
 
-    <Directory "/srv/htdocs">
+    <Directory "/srv/vanilla-repositories/vanilla">
         Options Indexes FollowSymLinks
         AllowOverride All
         Require all granted


### PR DESCRIPTION
This update make it easier for anyone to understand the internal mapping inside containers. ie. All cloned repositories are mapped under `/srv/vanilla-repositories`.

Also make sure that dev.vanilla.localhosts is the default config over https.