### PR TITLE
Comment container_name since it is currently preventing containers to start

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,10 +1,10 @@
-version: "3.5"
+version: "3.6"
 
 services:
     database:
         build:
             context: "./images/${VANILLA_DOCKER_DATABASE}"
-        container_name: "database"
+        #container_name: "database"
         environment:
             MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
         networks:

--- a/docker-compose.unit-tests.yml
+++ b/docker-compose.unit-tests.yml
@@ -1,11 +1,11 @@
-version: "3.5"
+version: "3.6"
 
 services:
     # It sucks that the extend command has been removed in docker-compose 3.x
     unit-test-php-fpm:
         build:
             context: "./images/php-fpm"
-        container_name: "unit-test-php-fpm"
+        #container_name: "unit-test-php-fpm"
         environment:
             - "PHP_INI_SCAN_DIR=:/usr/local/etc/php/custom.conf.d" # Allow users to override configs
             - "TEST_BASEURL"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,10 @@
-version: "3.5"
+version: "3.6"
 
 services:
     httpd:
         build:
             context: "./images/httpd"
-        container_name: "httpd"
+        #container_name: "httpd"
         depends_on:
             - "php-fpm"
         networks:
@@ -24,7 +24,7 @@ services:
             context: "./images/nginx"
         # Transform the template into an actual file
         command: /bin/bash -c "envsubst < /etc/nginx/fastcgi.conf.tpl > /etc/nginx/fastcgi.conf && nginx -g 'daemon off;'"
-        container_name: "nginx"
+        #container_name: "nginx"
         depends_on:
             - "php-fpm"
         environment:
@@ -62,7 +62,7 @@ services:
     php-fpm:
         build:
             context: "./images/php-fpm"
-        container_name: "php-fpm"
+        #container_name: "php-fpm"
         environment:
             - "PHP_INI_SCAN_DIR=:/usr/local/etc/php/custom.conf.d" # Allow users to override configs
             - "TEST_BASEURL"

--- a/service-memcached.yml
+++ b/service-memcached.yml
@@ -1,4 +1,4 @@
-version: "3.5"
+version: "3.6"
 services:
     #####
     ## Runs on the default port 11211

--- a/service-memcached.yml
+++ b/service-memcached.yml
@@ -28,4 +28,4 @@ services:
             context: "./images/memcached"
         networks:
             - "vanilla_network"
-        container_name: memcached
+        #container_name: "memcached"

--- a/service-sphinx.yml
+++ b/service-sphinx.yml
@@ -1,4 +1,4 @@
-version: "3.5"
+version: "3.6"
 services:
     #####
     ## Before enabling make sure that:
@@ -11,7 +11,7 @@ services:
     sphinx:
         build:
             context: "./images/sphinx"
-        container_name: sphinx
+        #container_name: "sphinx"
         networks:
             - "vanilla_network"
         volumes:


### PR DESCRIPTION
Not sure why exactly but container_name seems to be bugged.

```
Successfully tagged vanilla-docker_httpd:latest
Creating database ... error

ERROR: for database  Cannot create container for service database: Conflict. The container name "/database" is already in use by container "746674f120fa992704cf18d81f29a8c9cff59c79e480a2fe631673eda9d615a2". You have to remove (or rename) that container to be able to reuse that name.

ERROR: for database  Cannot create container for service database: Conflict. The container name "/database" is already in use by container "746674f120fa992704cf18d81f29a8c9cff59c79e480a2fe631673eda9d615a2". You have to remove (or rename) that container to be able to reuse that name.
```

Not using it "fixes" the issue.