### PR TITLE
Update installation documentation and markdown formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ php-fpm with PHP 7.2
 1. Move into your project directory.
 1. Clone or download [vanilla/vanilla-docker](https://github.com/vanilla/vanilla-docker) into your project directory.
 1. Clone or download [vanilla/vanilla](https://github.com/vanilla/vanilla) into your project directory.
-1. Clone or download any other project dependencies (for example, any of [vanilla/addons](https://github.com/vanilla/addons)), and install according to their instructions.
+1. Clone or download any other project dependencies into your project directory (for example, any of [vanilla/addons](https://github.com/vanilla/addons)), and install according to their instructions. _Note: All addons, plugins, themes, etc, must be located in the project directory. Everything outside of the project directory will not be made available inside of the Docker container._
 1. You should have the following structure
     ```
     my-vanilla-project

--- a/README.md
+++ b/README.md
@@ -49,16 +49,14 @@ php-fpm with PHP 7.2
 1. Get [Composer](https://getcomposer.org/) and install it.
 1. Create a directory for your project. In this example, we'll use `my-vanilla-project`, but you can use any name.
 1. Move into your project directory.
-1. Clone the following repos into your project directory:
-    1. [https://github.com/vanilla/vanilla](vanilla/vanilla)
-    1. [https://github.com/vanilla/vanilla-docker](vanilla/vanilla-docker)
-    1. [https://github.com/vanilla/addons](vanilla/addons)
+1. Clone or download [vanilla/vanilla-docker](https://github.com/vanilla/vanilla-docker) into your project directory.
+1. Clone or download [vanilla/vanilla](https://github.com/vanilla/vanilla) into your project directory.
+1. Clone or download any other project dependencies (for example, any of [vanilla/addons](https://github.com/vanilla/addons)), and install according to their instructions.
 1. You should have the following structure
     ```
     my-vanilla-project
     ├── vanilla
     ├── vanilla-docker
-    ├── addons
     ├── ...
     ```
 1. Move into the `vanilla` directory.

--- a/README.md
+++ b/README.md
@@ -46,39 +46,58 @@ php-fpm with PHP 7.2
 
 1. Get [Docker for OSX](https://download.docker.com/mac/stable/Docker.dmg) and install it.
     - Do not forget to tune up the allocated Memory and CPUs. `Docker` > `Preferences` > `Advanced`
-1. Create a `repositories` folder
-1. Clone all the wanted repositories in there.
-    - [https://github.com/vanilla/vanilla](vanilla/vanilla)
-        - It is recommended to use "vanilla_dev" as the database name since some services are configured to use that database.
-    - [https://github.com/vanilla/vanilla-docker](vanilla/vanilla-docker)
-    - [https://github.com/vanilla/addons](vanilla/addons)
-    - ...
+1. Get [Composer](https://getcomposer.org/) and install it.
+1. Create a directory for your project. In this example, we'll use `my-vanilla-project`, but you can use any name.
+1. Move into your project directory.
+1. Clone the following repos into your project directory:
+    1. [https://github.com/vanilla/vanilla](vanilla/vanilla)
+    1. [https://github.com/vanilla/vanilla-docker](vanilla/vanilla-docker)
+    1. [https://github.com/vanilla/addons](vanilla/addons)
 1. You should have the following structure
-```
-repositories
-├── vanilla
-├── vanilla-docker
-├── addons
-├── ...
-```
-1. Move into the `vanilla-docker` directory.
+    ```
+    my-vanilla-project
+    ├── vanilla
+    ├── vanilla-docker
+    ├── addons
+    ├── ...
+    ```
+1. Move into the `vanilla` directory.
+1. Run `composer install` which will install Vanilla's dependencies.
+1. Move up and over into the `vanilla-docker` directory.
 1. Run `sudo ./mac-setup.sh` which will:
     - Add a self signed certificate `*.vanilla.localhost` to your keychain.
     - Safely update your `/etc/hosts`.
     - Add `192.0.2.1` as a loopback IP address.
     - Create a docker volume named "datastorage" which will contain the database data.
-1. Run `docker-compose up --build` (It will take a while the first time) and voila -> [dev.vanilla.localhost](https://dev.vanilla.localhost/)
+1. Run `docker-compose up --build` (It will take a while the first time). You'll know it worked if you see something like
+    ```
+    Successfully built…
+    Successfully tagged…
+    Creating database ... done
+    Creating php-fpm  ... done
+    Creating httpd    ... done
+    Creating nginx    ... done
+    Attaching to database, php-fpm, httpd, nginx
+    …
+    php-fpm     | done.
+    ```
+    and voila -> [dev.vanilla.localhost](https://dev.vanilla.localhost/) shows the Vanilla installer.
+1. Run the installer!
+    - It is recommended to use `vanilla_dev` as the database name since some services are configured to use that database.
+
+To properly stop the containers you need to run `docker-compose down`.
 
 Do not forget to run `docker-compose up --build` to start up the services every time you restart your computer.
-To properly stop the containers you need to run `docker-compose down`.
 
 ##### Running optional services
 
 To run additional services (named service-*.yml) you can specify which .yml file to run like so:
 
-`docker-compose -f docker-compose.yml -f docker-compose.override.yml -f service-sphinx.yml up --build`
+```shell
+docker-compose -f docker-compose.yml -f docker-compose.override.yml -f service-sphinx.yml up --build
+```
 
-You can add as many services as you want that way. 
+You can add as many services as you want that way.
 *You can create a script named custom.boot.sh, with the combination of services that you want, so that it is easier to start the services that you want.*
 
 Generally, there should be documentation inside the .yml file of the service that gives you information about it.
@@ -87,28 +106,31 @@ For more information: [understanding-multiple-compose-files](https://docs.docker
 
 ##### Using your local database
 
-To start all container but the database one you can use:
+To start all containers except the database one you can use:
 
-`docker-compose -f docker-compose.yml up --build`
+```shell
+docker-compose -f docker-compose.yml up --build
+```
 
-This will skip `docker-compose.override.yml`. Note that by doing so you will probably have to add additional
-configurations to make sure that the database is reachable from the containers.
+This will skip `docker-compose.override.yml`. Note that by doing so you will probably have to add additional configurations to make sure that the database is reachable from the containers.
 
 To address that issue you have 2 ways of doing it:
-- You always have the possibility of using the loopback ip `192.0.2.1` that is installed by the `mac-setup.sh` script
-if your database is installed directly on your machine.
+- You always have the possibility of using the loopback ip `192.0.2.1` that is installed by the `mac-setup.sh` script if your database is installed directly on your machine.
 - You can also create custom.*.yml file to extends the existing services and add extra-hosts to the services. Example:
     `custom.dbhost.yml`
-    ```
+    ```yaml
     version: "3"
-    
+
     services:
         php-fpm:
             extra_hosts:
                 database: 192.0.2.1
 
     ```
-    You can then do: `docker-compose -f docker-compose.yml -f custom.dbhost.yml up --build`
+    You can then do:
+    ```shell
+    docker-compose -f docker-compose.yml -f custom.dbhost.yml up --build
+    ```
 
 You can also delete the datastorage volume created by `mac-setup.sh` since you won't be using it.
 
@@ -124,7 +146,6 @@ See [Make unit tests work within PhpStorm](./docs/unit-tests.md).
 
 Q. Why is everything so slow?
 
-A. You are probably running on the APFS file system that became the standard with macOS High Sierra and 
-which has pretty bad performance with Docker for Mac. 
-Having the database on your host instead os inside docker might help a lot. See [#10](https://github.com/vanilla/vanilla-docker/issues/10). 
+A. You are probably running on the APFS file system that became the standard with macOS High Sierra and which has pretty bad performance with Docker for Mac.
+Having the database on your host instead of inside docker might help a lot. See [#10](https://github.com/vanilla/vanilla-docker/issues/10).
 


### PR DESCRIPTION
Related to #32 

I ran into several problems while setting up vanilla-docker. Some of them are things that might trip up anyone who hasn't spent much time with Vanilla and Docker. This PR adds the things I was missing, up to the point of running the Vanilla installer (I had trouble there too, but then my project changed course).

The main addition is "run `composer install` in the vanilla directory"; there are also some markdown changes to better take advantage of Github's md-friendliness