### PR TITLE
Improve page latency with docker-sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ _notes
 .settings
 .buildpath
 .idea
+.docker-sync
 /custom.*.yml
 /custom.*.sh
 /*-xtra/

--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ php-fpm with PHP 7.2
 
 1. Get [Docker for OSX](https://download.docker.com/mac/stable/Docker.dmg) and install it.
     - Do not forget to tune up the allocated Memory and CPUs. `Docker` > `Preferences` > `Advanced`
+1. Install [docker-sync](https://github.com/EugenMayer/docker-sync)
+
+```ruby
+gem install docker-sync
+```
 1. Create a `repositories` folder
 1. Clone all the wanted repositories in there.
     - [https://github.com/vanilla/vanilla](vanilla/vanilla)
@@ -67,10 +72,12 @@ repositories
     - Safely update your `/etc/hosts`.
     - Add `192.0.2.1` as a loopback IP address.
     - Create a docker volume named "datastorage" which will contain the database data.
+1. Start Docker Sync `docker-sync start`. This will take a while the first time, but will be much faster on subsequent runs.
 1. Run `docker-compose up --build` (It will take a while the first time) and voila -> [dev.vanilla.localhost](https://dev.vanilla.localhost/)
 
 Do not forget to run `docker-compose up --build` to start up the services every time you restart your computer.
-To properly stop the containers you need to run `docker-compose down`.
+
+To properly stop the containers you need to run `docker-compose down` and `docker-sync stop`.
 
 ##### Running optional services
 

--- a/docker-compose.unit-tests.yml
+++ b/docker-compose.unit-tests.yml
@@ -21,11 +21,15 @@ services:
             - "./resources/certificates:/usr/local/share/ca-certificates" # Mount extra certificates
             - "./resources/sphinx:/sphinx" # expose sphinx API. We have to do this here because we need to be enable to update the plugin before we can start the container.
             - "./resources/usr/local/etc/php/conf.d:/usr/local/etc/php/custom.conf.d"
-            - "src-sync:/srv/vanilla-repositories:nocopy"
+            # Sync files that are writable only into the container (much faster using docker-sync with rsync strategy)
+            - "sources-sync/:/srv/vanilla-repositories:nocopy"
+            # Sync files that are writable in both directions.
+            - "../vanilla/conf/:/srv/vanilla-repositories/conf:delegated"
+            - "../vanilla/uploads/:/srv/vanilla-repositories/uploads:delegated"
 
 volumes:
     unit-test-shared:
-    src-sync:
+    sources-sync:
         external: true
 
 networks:

--- a/docker-compose.unit-tests.yml
+++ b/docker-compose.unit-tests.yml
@@ -21,10 +21,12 @@ services:
             - "./resources/certificates:/usr/local/share/ca-certificates" # Mount extra certificates
             - "./resources/sphinx:/sphinx" # expose sphinx API. We have to do this here because we need to be enable to update the plugin before we can start the container.
             - "./resources/usr/local/etc/php/conf.d:/usr/local/etc/php/custom.conf.d"
-            - "../:/srv/vanilla-repositories"
+            - "src-sync:/srv/vanilla-repositories:nocopy"
 
 volumes:
     unit-test-shared:
+    src-sync:
+        external: true
 
 networks:
     default:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,10 @@ services:
             - "./logs/httpd:/var/log/httpd"
             - "./resources/certificates:/certificates"
             - "./resources/usr/local/apache2/conf.d:/usr/local/apache2/conf.d"
-            - "src-sync/:/srv/vanilla-repositories:nocopy"
+            # Sync files that are writable only into the container (much faster using docker-sync with rsync strategy)
+            - "sources-sync/:/srv/vanilla-repositories:nocopy"
+            # Sync files that are writable in both directions.
+            - "../vanilla/uploads/:/srv/vanilla-repositories/uploads:delegated"
 
     nginx:
         build:
@@ -56,7 +59,10 @@ services:
             - "./resources/etc/nginx/conf.d:/etc/nginx/conf.d"
             - "./resources/etc/nginx/sites-available:/etc/nginx/sites-available"
             - "./resources/etc/nginx/sites-enabled:/etc/nginx/sites-enabled"
-            - "src-sync/:/srv/vanilla-repositories:nocopy"
+            # Sync files that are writable only into the container (much faster using docker-sync with rsync strategy)
+            - "sources-sync/:/srv/vanilla-repositories:nocopy"
+            # Sync files that are writable in both directions.
+            - "../vanilla/uploads/:/srv/vanilla-repositories/uploads:delegated"
 
     # Don't forget to update docker-compose.unit-test.yml
     php-fpm:
@@ -78,10 +84,15 @@ services:
             - "./resources/certificates:/usr/local/share/ca-certificates" # Mount extra certificates
             - "./resources/sphinx:/sphinx" # expose sphinx API. We have to do this here because we need to be enable to update the plugin before we can start the container.
             - "./resources/usr/local/etc/php/conf.d:/usr/local/etc/php/custom.conf.d"
-            - "src-sync/:/srv/vanilla-repositories:nocopy"
+            # Sync files that are writable only into the container (much faster using docker-sync with rsync strategy)
+            - "sources-sync/:/srv/vanilla-repositories:nocopy"
+            # Sync files that are writable in both directions.
+            - "../vanilla/cache/:/srv/vanilla-repositories/vanilla/cache:delegated"
+            - "../vanilla/conf/:/srv/vanilla-repositories/vanilla/conf:cached"
+            - "../vanilla/uploads/:/srv/vanilla-repositories/vanilla/uploads:cached"
 
 volumes:
-    src-sync:
+    sources-sync:
         external: true
     shared:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,9 +81,9 @@ services:
             - "src-sync/:/srv/vanilla-repositories:nocopy"
 
 volumes:
-    shared:
     src-sync:
         external: true
+    shared:
 
 networks:
     vanilla_network:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
             - "./logs/httpd:/var/log/httpd"
             - "./resources/certificates:/certificates"
             - "./resources/usr/local/apache2/conf.d:/usr/local/apache2/conf.d"
-            - "../:/srv/vanilla-repositories"
+            - "src-sync/:/srv/vanilla-repositories:nocopy"
 
     nginx:
         build:
@@ -56,7 +56,7 @@ services:
             - "./resources/etc/nginx/conf.d:/etc/nginx/conf.d"
             - "./resources/etc/nginx/sites-available:/etc/nginx/sites-available"
             - "./resources/etc/nginx/sites-enabled:/etc/nginx/sites-enabled"
-            - "../:/srv/vanilla-repositories"
+            - "src-sync/:/srv/vanilla-repositories:nocopy"
 
     # Don't forget to update docker-compose.unit-test.yml
     php-fpm:
@@ -78,12 +78,15 @@ services:
             - "./resources/certificates:/usr/local/share/ca-certificates" # Mount extra certificates
             - "./resources/sphinx:/sphinx" # expose sphinx API. We have to do this here because we need to be enable to update the plugin before we can start the container.
             - "./resources/usr/local/etc/php/conf.d:/usr/local/etc/php/custom.conf.d"
-            - "../:/srv/vanilla-repositories"
+            - "src-sync/:/srv/vanilla-repositories:nocopy"
 
 volumes:
     shared:
+    src-sync:
+        external: true
 
 networks:
     vanilla_network:
         driver: "bridge"
         name: "vanilla_network"
+

--- a/docker-sync.yml
+++ b/docker-sync.yml
@@ -4,5 +4,8 @@ syncs:
   #IMPORTANT: ensure this name is unique and does not match your other application container name
   src-sync:
     src: '../'
-    sync_excludes: ['Gemfile.lock', 'Gemfile', 'config.rb', '.sass-cache', '.awcache', 'sass', 'sass-cache', 'bower.json', 'package.json', 'Gruntfile*', 'bower_components', 'node_modules', '.gitignore', '.git', '*.coffee', '*.scss', '*.sass']
+    sync_excludes: ['Gemfile.lock', 'Gemfile', 'config.rb', '.sass-cache', '.awcache', 'sass', 'sass-cache', 'bower.json', 'package.json', 'Gruntfile*', 'bower_components', 'node_modules', '.gitignore', '.git', '*.coffee', '*.scss', '*.sass', 'vanilla-docker', '.idea', '.vscode']
+    monit_enable: false
+    sync_groupid: '33'
+    sync_userid: '33' # PHP-FPM user. Otherwise PHP doesn't have permission to change files.
 

--- a/docker-sync.yml
+++ b/docker-sync.yml
@@ -1,0 +1,8 @@
+version: "2"
+
+syncs:
+  #IMPORTANT: ensure this name is unique and does not match your other application container name
+  src-sync:
+    src: '../'
+    sync_excludes: ['Gemfile.lock', 'Gemfile', 'config.rb', '.sass-cache', '.awcache', 'sass', 'sass-cache', 'bower.json', 'package.json', 'Gruntfile*', 'bower_components', 'node_modules', '.gitignore', '.git', '*.coffee', '*.scss', '*.sass']
+

--- a/docker-sync.yml
+++ b/docker-sync.yml
@@ -2,10 +2,10 @@ version: "2"
 
 syncs:
   #IMPORTANT: ensure this name is unique and does not match your other application container name
-  src-sync:
+  sources-sync:
     src: '../'
-    sync_excludes: ['Gemfile.lock', 'Gemfile', 'config.rb', '.sass-cache', '.awcache', 'sass', 'sass-cache', 'bower.json', 'package.json', 'Gruntfile*', 'bower_components', 'node_modules', '.gitignore', '.git', '*.coffee', '*.scss', '*.sass', 'vanilla-docker', '.idea', '.vscode']
-    monit_enable: false
-    sync_groupid: '33'
-    sync_userid: '33' # PHP-FPM user. Otherwise PHP doesn't have permission to change files.
+    sync_strategy: 'rsync'
+    sync_host_port: 10872
+    sync_excludes: ['Gemfile.lock', 'Gemfile', 'config.rb', '.sass-cache', '.awcache', 'sass', 'sass-cache', 'bower.json', 'package.json', 'Gruntfile*', 'bower_components', 'node_modules', '.gitignore', '.git', '*.coffee', '*.scss', '*.sass', 'vanilla-docker', '.idea', '.vscode', 'vanilla/cache', 'vanilla/conf', 'vanilla/uploads']
+    sync_args: "-L" # Needed or symlinks don't work.
 

--- a/images/php-fpm/Dockerfile
+++ b/images/php-fpm/Dockerfile
@@ -9,11 +9,14 @@ RUN apt-get update \
         libpng-dev \
         sendmail \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install -j$(nproc) gd mbstring pdo pdo_mysql \
+    && docker-php-ext-install -j$(nproc) gd mbstring pdo pdo_mysql zip \
     && pecl install xdebug \
     && docker-php-ext-enable xdebug \
     && pecl install memcached \
     && docker-php-ext-enable memcached
+
+# Install composer
+RUN php -r "readfile('http://getcomposer.org/installer');" | php -- --install-dir=/usr/bin/ --filename=composer
 
 # Cleanup apt
 RUN rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This speeds up the site running and unit tests running by a significant amount.

## Before (no docker-sync)

#### Time to document received on the `/settings/themes` page
<img width="566" alt="screen shot 2018-07-03 at 2 28 06 pm" src="https://user-images.githubusercontent.com/1770056/42238005-8557822e-7ecd-11e8-8ff4-17af36e45fb2.png">

#### Time to document received on the `/settings/plugins` page

<img width="566" alt="screen shot 2018-07-03 at 2 30 32 pm" src="https://user-images.githubusercontent.com/1770056/42238057-a9cfa276-7ecd-11e8-963f-7588cae4d004.png">


#### Time to document received on the `/discussions` page
<img width="564" alt="screen shot 2018-07-03 at 2 29 48 pm" src="https://user-images.githubusercontent.com/1770056/42238019-91ba2616-7ecd-11e8-9a26-08245bf2a740.png">

#### Time to run Tests

**Total: 3.19 minutes**

![image](https://user-images.githubusercontent.com/1770056/42239451-ef7b41b4-7ed1-11e8-887d-865e40929c4c.png)

## After (with docker-sync)

#### Time to document received on the `/settings/themes` page

![image](https://user-images.githubusercontent.com/1770056/42239045-bbceb400-7ed0-11e8-8c28-4b7f5562ff26.png)

#### Time to document received on the `/settings/plugins` page

![image](https://user-images.githubusercontent.com/1770056/42239024-ae68a492-7ed0-11e8-930d-7182458ccf24.png)

#### Time to document received on the `/discussions` page

![image](https://user-images.githubusercontent.com/1770056/42239064-c923d39c-7ed0-11e8-8a6a-bc85bf43bcd2.png)

#### Time to run Tests

Total: 3.27 minutes

![image](https://user-images.githubusercontent.com/1770056/42238407-afe73326-7ece-11e8-93c8-135a826d7a7d.png)

## Working things

- The actual vanilla site.
- File uploads
- Addons modifying files that are synced in.

## Broken things

Two things are broken here.

1. ~~Vanilla loads it's addon classes and doesn't actually check whether a class directory is uppercase or lowercase.~~

**This was resolved by doing a composer install/autoloader generation on a case-sensitive file system. To accomplish this I had to add composer and the zip extension into the PHP container.** This will still be broken if you do a composer install on a case-insensitive file system then try and use that autoload file on a case-sensitive file system.

~~https://github.com/vanilla/vanilla/blob/master/library/Vanilla/Addon.php#L497-L508~~

~~In this case the real on the filesystem `Controller`, `Module`, `Model` directories get overridden by paths with an uppercase name on a case-insensitive file system. In our case we are building the addon cache on a case-insensitive file system and then trying to use that cache on a case-sensitive file system.~~

~~For the purposes of testing this I removed scanning for upper case folder names.~~

2. ~~Our tests using `cgi-bin/saveconfig.php` `SimpleConfig::deleteConfig()` all fail. It alternates between an error in install and uninstall. This 100% down to permission errors. I might not be setting the group_id and user_id docker-sync settings to the correct values.~~

**This was resolved by using docker-sync for everything except for server writable files. The server writable files synced the standard way that docker syncs files**

~~I tried setting `sync_user_id` to the `www-data` user and that seems to allow php-fpm to editor files that are synced in, but it can't seem to modify files that it created itself. One solution here, would be generate the test files to a directory that is not being synced back and forth of the docker sync. We really only want to be syncing our source code with this.~~
