### PR TITLE
Delegate storage on PHP-fpm containers

### DIFF
--- a/docker-compose.unit-tests.yml
+++ b/docker-compose.unit-tests.yml
@@ -21,7 +21,7 @@ services:
             - "./resources/certificates:/usr/local/share/ca-certificates" # Mount extra certificates
             - "./resources/sphinx:/sphinx" # expose sphinx API. We have to do this here because we need to be enable to update the plugin before we can start the container.
             - "./resources/usr/local/etc/php/conf.d:/usr/local/etc/php/custom.conf.d"
-            - "../:/srv/vanilla-repositories"
+            - "../:/srv/vanilla-repositories:delegated"
 
 volumes:
     unit-test-shared:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,7 +78,7 @@ services:
             - "./resources/certificates:/usr/local/share/ca-certificates" # Mount extra certificates
             - "./resources/sphinx:/sphinx" # expose sphinx API. We have to do this here because we need to be enable to update the plugin before we can start the container.
             - "./resources/usr/local/etc/php/conf.d:/usr/local/etc/php/custom.conf.d"
-            - "../:/srv/vanilla-repositories"
+            - "../:/srv/vanilla-repositories:delegated"
 
 volumes:
     shared:


### PR DESCRIPTION
This yields a significant speedup (particularly with latency) compared to non-delegated volumes in the fpm container.

This does mean there can be a slight delay when in syncing back to host (~200ms), but this is not really significant.

All unit tests (including the alt test) still pass with this change.