### PR TITLE
Mount read only volume with "cached" and write volumes with "delegated"

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -12,7 +12,7 @@ services:
         ports:
             - "3306:3306"
         volumes:
-            - "./logs/${VANILLA_DOCKER_DATABASE}:/var/log/mysql"
+            - "./logs/${VANILLA_DOCKER_DATABASE}:/var/log/mysql:delegated"
             - "./resources/etc/mysql/conf.d/:/etc/mysql/conf.d/"
             - "datastorage:/var/lib/mysql"
 

--- a/docker-compose.unit-tests.yml
+++ b/docker-compose.unit-tests.yml
@@ -17,10 +17,10 @@ services:
           - "nginx"
         volumes:
             - "unit-test-shared:/shared" # expose php-fpm socket
-            - "./logs/php-fpm:/var/log/php-fpm"
-            - "./resources/certificates:/usr/local/share/ca-certificates" # Mount extra certificates
-            - "./resources/sphinx:/sphinx" # expose sphinx API. We have to do this here because we need to be enable to update the plugin before we can start the container.
-            - "./resources/usr/local/etc/php/conf.d:/usr/local/etc/php/custom.conf.d"
+            - "./logs/php-fpm:/var/log/php-fpm:delegated"
+            - "./resources/certificates:/usr/local/share/ca-certificates:cached" # Mount extra certificates
+            - "./resources/sphinx:/sphinx:cached" # expose sphinx API. We have to do this here because we need to be enable to update the plugin before we can start the container.
+            - "./resources/usr/local/etc/php/conf.d:/usr/local/etc/php/custom.conf.d:cached"
             - "../:/srv/vanilla-repositories:delegated"
 
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,10 +14,10 @@ services:
             - "9443:9443"
         volumes:
             - "shared:/shared" # allow to use the php-fpm socket
-            - "./logs/httpd:/var/log/httpd"
-            - "./resources/certificates:/certificates"
-            - "./resources/usr/local/apache2/conf.d:/usr/local/apache2/conf.d"
-            - "../:/srv/vanilla-repositories"
+            - "./logs/httpd:/var/log/httpd:delegated"
+            - "./resources/certificates:/certificates:cached"
+            - "./resources/usr/local/apache2/conf.d:/usr/local/apache2/conf.d:cached"
+            - "../:/srv/vanilla-repositories:cached"
 
     nginx:
         build:
@@ -51,12 +51,12 @@ services:
             - "443:443"
         volumes:
             - "shared:/shared" # allow to use the php-fpm socket
-            - "./logs/nginx:/var/log/nginx"
-            - "./resources/certificates:/certificates"
-            - "./resources/etc/nginx/conf.d:/etc/nginx/conf.d"
-            - "./resources/etc/nginx/sites-available:/etc/nginx/sites-available"
-            - "./resources/etc/nginx/sites-enabled:/etc/nginx/sites-enabled"
-            - "../:/srv/vanilla-repositories"
+            - "./logs/nginx:/var/log/nginx:delegated"
+            - "./resources/certificates:/certificates:cached"
+            - "./resources/etc/nginx/conf.d:/etc/nginx/conf.d:cached"
+            - "./resources/etc/nginx/sites-available:/etc/nginx/sites-available:cached"
+            - "./resources/etc/nginx/sites-enabled:/etc/nginx/sites-enabled:cached"
+            - "../:/srv/vanilla-repositories:cached"
 
     # Don't forget to update docker-compose.unit-test.yml
     php-fpm:
@@ -74,10 +74,10 @@ services:
             - "vanilla_network"
         volumes:
             - "shared:/shared" # expose php-fpm socket
-            - "./logs/php-fpm:/var/log/php-fpm"
-            - "./resources/certificates:/usr/local/share/ca-certificates" # Mount extra certificates
-            - "./resources/sphinx:/sphinx" # expose sphinx API. We have to do this here because we need to be enable to update the plugin before we can start the container.
-            - "./resources/usr/local/etc/php/conf.d:/usr/local/etc/php/custom.conf.d"
+            - "./logs/php-fpm:/var/log/php-fpm:delegated"
+            - "./resources/certificates:/usr/local/share/ca-certificates:cached" # Mount extra certificates
+            - "./resources/sphinx:/sphinx:cached" # expose sphinx API. We have to do this here because we need to be enable to update the plugin before we can start the container.
+            - "./resources/usr/local/etc/php/conf.d:/usr/local/etc/php/custom.conf.d:cached"
             - "../:/srv/vanilla-repositories:delegated"
 
 volumes:

--- a/service-sphinx.yml
+++ b/service-sphinx.yml
@@ -16,6 +16,6 @@ services:
         networks:
             - "vanilla_network"
         volumes:
-            - ./logs/sphinx:/var/log/sphinx
-            - ./resources/usr/local/etc/sphinx/conf.d:/usr/local/etc/sphinx/conf.d
-            - ./resources/usr/local/etc/sphinx/configs-available/:/usr/local/etc/sphinx/configs-available/
+            - "./logs/sphinx:/var/log/sphinx:delegated"
+            - "./resources/usr/local/etc/sphinx/conf.d:/usr/local/etc/sphinx/conf.d:cached"
+            - "./resources/usr/local/etc/sphinx/configs-available/:/usr/local/etc/sphinx/configs-available/:cached"


### PR DESCRIPTION
Follow up of https://github.com/vanilla/vanilla-docker/pull/36

See: https://docs.docker.com/docker-for-mac/osxfs-caching/#tuning-with-consistent-cached-and-delegated-configurations

