### PR TITLE
Add intl php extension and do some cleanup/updates

### DIFF
--- a/images/memcached/Dockerfile
+++ b/images/memcached/Dockerfile
@@ -1,1 +1,1 @@
-FROM memcached:1.5.6
+FROM memcached:1.5

--- a/images/nginx/Dockerfile
+++ b/images/nginx/Dockerfile
@@ -1,5 +1,5 @@
 # Pull base image.
-FROM nginx:1.13
+FROM nginx:1.15
 
 COPY ./etc/nginx/nginx.conf /etc/nginx/nginx.conf
 COPY ./etc/nginx/fastcgi.conf.tpl /etc/nginx/fastcgi.conf.tpl

--- a/images/php-fpm/Dockerfile
+++ b/images/php-fpm/Dockerfile
@@ -1,22 +1,40 @@
 FROM php:7.2-fpm-stretch
 
-RUN apt-get update \
+RUN set -xe; \
+    apt-get update \
     && apt-get install -y \
+        # for intl extension
+        libicu-dev \
+        # for gd
         libfreetype6-dev \
         libjpeg62-turbo-dev \
-        libmcrypt-dev \
-        libmemcached-dev \
         libpng-dev \
+        # memchached extension
+        libmemcached-dev \
+        # allow mailing to work
         sendmail \
-    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install -j$(nproc) gd mbstring pdo pdo_mysql \
+    # pecl installs
     && pecl install xdebug \
-    && docker-php-ext-enable xdebug \
     && pecl install memcached \
-    && docker-php-ext-enable memcached
-
-# Cleanup apt
-RUN rm -rf /var/lib/apt/lists/*
+    && pecl clear-cache \
+    # built in extensions install
+    && docker-php-ext-install -j$(nproc) \
+        gd \
+        mbstring \
+        pdo \
+        pdo_mysql \
+        intl \
+    # configurations
+    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
+    && docker-php-ext-configure intl \
+    # enable extentions
+    && docker-php-ext-enable xdebug \
+    && docker-php-ext-enable memcached \
+    # cleanup
+    && rm -rf \
+        /var/lib/apt/lists/* \
+        /usr/src/php/ext/* \
+        /tmp/*
 
 COPY ./usr/local/etc/php-fpm.conf /usr/local/etc/php-fpm.conf
 COPY ./usr/local/etc/php/conf.d/00-php.ini /usr/local/etc/php/conf.d/00-php.ini

--- a/images/php-fpm/Dockerfile
+++ b/images/php-fpm/Dockerfile
@@ -16,21 +16,19 @@ RUN set -xe; \
     # pecl installs
     && pecl install xdebug \
     && pecl install memcached \
-    && pecl clear-cache \
+    # enable pecl installed extentions
+    && docker-php-ext-enable xdebug \
+    && docker-php-ext-enable memcached \
     # built in extensions install
+    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install -j$(nproc) \
         gd \
         mbstring \
         pdo \
         pdo_mysql \
         intl \
-    # configurations
-    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-configure intl \
-    # enable extentions
-    && docker-php-ext-enable xdebug \
-    && docker-php-ext-enable memcached \
     # cleanup
+    && pecl clear-cache \
     && rm -rf \
         /var/lib/apt/lists/* \
         /usr/src/php/ext/* \


### PR DESCRIPTION
Some of our plugins require the [intl](http://php.net/manual/en/book.intl.php) extension to be installed.

- Add intl extension
- Remove libmcrypt-dev dependency (It's not used by php anymore)
- Add more cleanup
- Bumb nginx version
- Lock memcached version to minor instead of patch
