### PR TITLE
Add a config file for comments-embed stub.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ _notes
 !/resources/etc/nginx/sites-available/vanilla.test.conf
 !/resources/etc/nginx/sites-available/embed.vanilla.localhost.conf
 !/resources/etc/nginx/sites-available/advanced-embed.vanilla.localhost.conf
+!/resources/etc/nginx/sites-available/comments-embed.vanilla.localhost.conf
 /resources/etc/nginx/sites-enabled/*
 /resources/usr/local/apache2/conf.d/*
 !/resources/usr/local/apache2/conf.d/vanilla.localhost.ssl.conf

--- a/resources/etc/nginx/sites-available/comments-embed.vanilla.localhost.conf
+++ b/resources/etc/nginx/sites-available/comments-embed.vanilla.localhost.conf
@@ -1,0 +1,24 @@
+server {
+
+    server_name comments-embed.vanilla.localhost;
+    listen 80;
+
+    listen 443 ssl;
+    ssl_certificate      /certificates/vanilla.localhost.crt;
+    ssl_certificate_key  /certificates/vanilla.localhost.key;
+
+    root /srv/vanilla-repositories/stub-embed-providers/comments;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ @htmlext;
+    }
+
+    location ~ \.html$ {
+        try_files $uri =404;
+    }
+
+    location @htmlext {
+        rewrite ^(.*)$ $1.html last;
+    }
+}

--- a/resources/etc/nginx/sites-enabled/comments-embed.vanilla.localhost.conf
+++ b/resources/etc/nginx/sites-enabled/comments-embed.vanilla.localhost.conf
@@ -1,0 +1,1 @@
+../sites-available/comments-embed.vanilla.localhost.conf


### PR DESCRIPTION
Add a config file so that we could have a local stub for testing the embedding of comments in an article or blog page.

This would close issue: https://github.com/vanilla/stub-embed-providers/issues/2