### PR TITLE
add example of nginx configuration to generate cache header for stati…

### DIFF
--- a/resources/etc/nginx/sites-available/dev.vanilla.localhost.conf
+++ b/resources/etc/nginx/sites-available/dev.vanilla.localhost.conf
@@ -22,6 +22,20 @@ server {
 
     location ^~ "/favicon.ico" { access_log off; log_not_found off; return 404; }
 
+    # Set cache headers for static content when found
+    # if not redirect to index.php to try to find any dynamicly generated resource
+    # application will reset cache headers according to the app configuration
+    location ~* \.(jpg|jpeg|png|gif|ico|css|js)$ {
+        expires 30d;
+        try_files $uri @static;
+    }
+    location @static {
+        include fastcgi.conf;
+        fastcgi_pass php-fpm;
+        fastcgi_param X_VANILLA 1;
+        rewrite ^ /index.php?p=$uri last;
+    }
+
     # /index.php handler
     location ~* "^/index\.php(/|$)" {
         # send to fastcgi


### PR DESCRIPTION
Add example of nginx configuration to generate cache header for static content.

```
    # Set cache headers for static content when found
    # if not redirect to index.php to try to find any dynamicly generated resource
    # application will reset cache headers according to the app configuration
```

### Note

Apache configuration already has this headers implemented:

https://github.com/vanilla/vanilla/blob/d0e033990b4e57cdf91284814ae583612e02e226/.htaccess.dist#L50

Closes: https://github.com/vanilla/vanilla-patches/issues/565