### PR TITLE
Add EXIF module to PHP-FPM containers

### DIFF
--- a/images/php-fpm/Dockerfile
+++ b/images/php-fpm/Dockerfile
@@ -14,7 +14,7 @@ RUN set -xe; \
         # allow mailing to work
         sendmail \
     # pecl installs
-    && apt-get -yqq install exiftool\
+    && apt-get -yqq install exiftool \
     && docker-php-ext-configure exif \
     && docker-php-ext-install exif \
     && docker-php-ext-enable exif \

--- a/images/php-fpm/Dockerfile
+++ b/images/php-fpm/Dockerfile
@@ -13,8 +13,9 @@ RUN set -xe; \
         libmemcached-dev \
         # allow mailing to work
         sendmail \
+        # allow reading of image exif
+        exiftool \
     # pecl installs
-    && apt-get -yqq install exiftool \
     && docker-php-ext-configure exif \
     && docker-php-ext-install exif \
     && docker-php-ext-enable exif \

--- a/images/php-fpm/Dockerfile
+++ b/images/php-fpm/Dockerfile
@@ -33,7 +33,10 @@ RUN set -xe; \
         /var/lib/apt/lists/* \
         /usr/src/php/ext/* \
         /tmp/*
-
+RUN apt-get -yqq install exiftool
+RUN docker-php-ext-configure exif
+RUN docker-php-ext-install exif
+RUN docker-php-ext-enable exif
 COPY ./usr/local/etc/php-fpm.conf /usr/local/etc/php-fpm.conf
 COPY ./usr/local/etc/php/conf.d/00-php.ini /usr/local/etc/php/conf.d/00-php.ini
 COPY ./usr/local/etc/php/conf.d/10-xdebug.ini /usr/local/etc/php/conf.d/10-xdebug.ini

--- a/images/php-fpm/Dockerfile
+++ b/images/php-fpm/Dockerfile
@@ -14,6 +14,10 @@ RUN set -xe; \
         # allow mailing to work
         sendmail \
     # pecl installs
+    && apt-get -yqq install exiftool\
+    && docker-php-ext-configure exif \
+    && docker-php-ext-install exif \
+    && docker-php-ext-enable exif \
     && pecl install xdebug \
     && pecl install memcached \
     # enable pecl installed extentions
@@ -33,10 +37,6 @@ RUN set -xe; \
         /var/lib/apt/lists/* \
         /usr/src/php/ext/* \
         /tmp/*
-RUN apt-get -yqq install exiftool
-RUN docker-php-ext-configure exif
-RUN docker-php-ext-install exif
-RUN docker-php-ext-enable exif
 COPY ./usr/local/etc/php-fpm.conf /usr/local/etc/php-fpm.conf
 COPY ./usr/local/etc/php/conf.d/00-php.ini /usr/local/etc/php/conf.d/00-php.ini
 COPY ./usr/local/etc/php/conf.d/10-xdebug.ini /usr/local/etc/php/conf.d/10-xdebug.ini

--- a/images/php-fpm/Dockerfile
+++ b/images/php-fpm/Dockerfile
@@ -16,14 +16,13 @@ RUN set -xe; \
         # allow reading of image exif
         exiftool \
     # pecl installs
-    && docker-php-ext-configure exif \
     && docker-php-ext-install exif \
-    && docker-php-ext-enable exif \
     && pecl install xdebug \
     && pecl install memcached \
     # enable pecl installed extentions
     && docker-php-ext-enable xdebug \
     && docker-php-ext-enable memcached \
+    && docker-php-ext-enable exif \
     # built in extensions install
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install -j$(nproc) \


### PR DESCRIPTION
PHP's [EXIF extension](https://www.php.net/manual/en/book.exif.php) is now available to the PHP-FPM containers. This will grant improved image handling capabilities (see vanilla/vanilla#9116) to Vanilla sites running in the Docker environment.