### PR TITLE
Tweak knowledge sphinx templates

### DIFF
--- a/resources/usr/local/etc/sphinx/configs-available/knowledge-standard.sphinx.conf
+++ b/resources/usr/local/etc/sphinx/configs-available/knowledge-standard.sphinx.conf
@@ -148,14 +148,14 @@ source vanilla_dev_KnowledgeArticle {
     sql_query = SELECT \
             ar.articleRevisionID * 10 + 5, \
             ar.articleRevisionID, \
-            a.articleID as DiscussionID, \
+            ar.articleRevisionID * 10 + 5 as DiscussionID, \
             0 as CategoryID, \
             a.knowledgeCategoryID, \
             a.insertUserID, \
             a.updateUserID, \
-            5 as dtype, \
+            500 as dtype, \
             0 as IP, \
-            5 as score, \
+            1000 as score, \
             unix_timestamp(a.DateInserted) as DateInserted, \
             unix_timestamp(a.dateUpdated) as dateUpdated, \
             ar.name, \
@@ -188,14 +188,14 @@ source vanilla_dev_KnowledgeArticle_Delta: vanilla_dev_KnowledgeArticle {
     sql_query = SELECT \
                 ar.articleRevisionID * 10 + 5, \
                 ar.articleRevisionID, \
-                a.articleID as DiscussionID, \
+                ar.articleRevisionID * 10 + 5 as DiscussionID, \
                 0 as CategoryID, \
                 a.knowledgeCategoryID, \
                 a.insertUserID, \
                 a.updateUserID, \
-                5 as dtype, \
+                500 as dtype, \
                 0 as IP, \
-                5 as score, \
+                1000 as score, \
                 unix_timestamp(a.DateInserted) as DateInserted, \
                 unix_timestamp(a.dateUpdated) as dateUpdated, \
                 ar.name, \


### PR DESCRIPTION
- Make the discussionID the unique ID so that articles don’t group in search results.
- Set the dtype of articles to 500.
- Set the default score of articles to 1000 to make them appear higher in search.

See https://github.com/vanilla/agentresources/pull/155