### PR TITLE
Removed duplicate attribute knowledgeBaseID

### DIFF
--- a/resources/usr/local/etc/sphinx/configs-available/everything.sphinx.conf
+++ b/resources/usr/local/etc/sphinx/configs-available/everything.sphinx.conf
@@ -182,7 +182,6 @@ source vanilla_dev_KnowledgeArticle {
     sql_attr_uint = updateUserID
     sql_attr_string = locale
     sql_attr_string = siteSectionGroup
-    sql_attr_uint = knowledgeBaseID
     sql_attr_uint = dtype
     sql_attr_uint = ip
     sql_attr_float = score


### PR DESCRIPTION
There were duplicate attributes declared.  This error only exists on the everything.sphinx.conf.  I checked the config deployed to infrastructure and it's fine.
  
fixes the error being thrown when sphinx is reindexing.
`ERROR: duplicate attribute name: knowledgebaseid`