### PR TITLE
Allow for alternate domains to install with /conf/host.php configs

### DIFF
--- a/bootstrap.before.php
+++ b/bootstrap.before.php
@@ -9,15 +9,20 @@ call_user_func(function () {
     $host = $_SERVER['HTTP_HOST'];
     [$host, $port] = explode(':', $host, 2) + ['', ''];
 
-    // Whitelinst to a domain. This can probably get removed at some point.
-    if (!in_array($host, ['vanilla.localhost'], true)) {
+    // Whitelist to a domain. This can probably get removed at some point.
+    if (in_array($host, ['dev.vanilla.localhost'], true)) {
+        // This is the default conf/config.php based install.
         return;
+    } elseif (!in_array($host, ['vanilla.localhost'], true)) {
+        // This is a conf/{$host}.php based install.
+        $configPath = PATH_ROOT . "/conf/$host.php";
+    } else {
+        // This domain treats the root directory as its own virtual root.
+        [$root, $_] = explode('/', ltrim($_SERVER['SCRIPT_NAME'], '/'), 2) + ['', ''];
+        // Use a config specific to the site.
+        $configPath = PATH_ROOT . "/conf/$host/$root.php";
     }
 
-    // This domain treats the root directory as its own virtual root.
-    [$root, $_] = explode('/',ltrim($_SERVER['SCRIPT_NAME'], '/'), 2) + ['', ''];
-    // Use a config specific to the site.
-    $configPath = PATH_ROOT."/conf/$host/$root.php";
     if (!file_exists(dirname($configPath))) {
         mkdir(dirname($configPath), 0755, true);
     }


### PR DESCRIPTION
Our APIv0 test harness looks for a `/conf/vanilla.test.php` install and doesn’t actually test properly if the web server doesn’t work this way. For CI we have an alternate bootstrap, but it would be nice to be able to run tests locally too.

If devs have their own favorite localhost domain then they can either use the different config path or whitelist their domain as a PR.