### PR TITLE
🎉 Speed up vanilla docker significantly with docker-sync 🎉

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ Thumbs.db
 *.swp
 _notes
 ~*
+.docker-sync
 .project
 .settings
 .buildpath

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ In order to changer to the RAW data format for docker, you need to do the follow
 
 - Backup any databases you have.
 - Open the docker troubleshooting page. (Open docker settings, click the "Bug" icon next to settings.)
-- Click on `Reset disk image`.
+- Click on `Clean / Purge data` ~`Reset disk image`.~ (It was renamed recently)
 - Wait until that completes.
 - Run the setup script again.
 - Start docker `vanilla-start`.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## Vanilla Docker environment
 
-*Only supports Mac OSX at the moment but everything can be easily adapted to work on other platforms.*
-*Assume that you are using [PhpStorm](https://www.jetbrains.com/phpstorm/) as your IDE.*
+_Only supports Mac OSX at the moment but everything can be easily adapted to work on other platforms._
+_Assume that you are using [PhpStorm](https://www.jetbrains.com/phpstorm/) as your IDE._
 
 This repository contains a ready-for-development environment to develop against Vanilla.
 
@@ -30,12 +30,12 @@ Apache 2 web server.
 nginx web server
 
 - Serve:
-    - https://dev.vanilla.localhost (main forum)
-    - https://vanilla.localhost/dev (directory-based main forum, see [the docs](docs/vanilla-localhost-dirs.md))
-    - https://sso.vanilla.localhost ([stub-sso-providers](https://github.com/vanilla/stub-sso-providers))
-    - https://embed.vanilla.localhost ([stub-embed-providers](https://github.com/vanilla/stub-embed-providers))
-    - https://advanced-embed.vanilla.localhost ([stub-embed-providers](https://github.com/vanilla/stub-embed-providers))
-    - http://vanilla.test:8080 (unit tests address)
+  - https://dev.vanilla.localhost (main forum)
+  - https://vanilla.localhost/dev (directory-based main forum, see [the docs](docs/vanilla-localhost-dirs.md))
+  - https://sso.vanilla.localhost ([stub-sso-providers](https://github.com/vanilla/stub-sso-providers))
+  - https://embed.vanilla.localhost ([stub-embed-providers](https://github.com/vanilla/stub-embed-providers))
+  - https://advanced-embed.vanilla.localhost ([stub-embed-providers](https://github.com/vanilla/stub-embed-providers))
+  - http://vanilla.test:8080 (unit tests address)
 
 ### php-fpm
 
@@ -43,11 +43,12 @@ php-fpm with PHP 7.3
 
 ### Sphinx
 
-Sphinx search service (service-sphinx.yml). 
+Sphinx search service (service-sphinx.yml).
 
 #### Installing Sphinx
 
 Before enabling make sure that:
+
 - Your database is named vanilla_dev
 - You have set `Plugins.Sphinx.Server = sphinx` in your config
 - You have set `Plugins.Sphinx.SphinxAPIDir = /sphinx/` in your config
@@ -57,10 +58,11 @@ Before enabling make sure that:
 - For unit tests use the everything.sphinx.conf
 
 #### Sphinx unit testing config
+
 - Ensure you have a test database `vanilla_test`.
 - Ensure you are using the `everything.sphinx.conf` config for sphinx.
 - Ensure that your phpunit.xml and phpunit.dist.xml have the following environmental value:
-`<env name="TEST_SPHINX_HOST" value="sphinx" />`
+  `<env name="TEST_SPHINX_HOST" value="sphinx" />`
 
 #### Re-indexing your database
 
@@ -74,79 +76,91 @@ docker exec -t sphinx bash /root/index.all.sh
 #### Installing the Sphinx indexr crontab
 
 If you need to have Sphinx indexes updated regularly run [install-sphinx-cron.sh](./images/sphinx/root/install-sphinx-cron.sh).
+
 - by default it will reindex delta indexes every minute and reindex all indexes every 5 min.
 - by default cron jobs hit `sphinx` container
-- if your environment or tasked to be different you need to change  `install-sphinx-cron.sh`
- accordingly
+- if your environment or tasked to be different you need to change `install-sphinx-cron.sh`
+  accordingly
 
- Note that the easiest way to run this script is through docker:
+Note that the easiest way to run this script is through docker:
 
- ```
+```
 docker exec -t sphinx bash /root/install-sphinx-cron.sh
- ```
+```
 
 ## Setup
 
-*For this setup to work properly you need to clone all vanilla repositories in the same base directory*
+_For this setup to work properly you need to clone all vanilla repositories in the same base directory_
 
 1. Get [Docker for OSX](https://download.docker.com/mac/stable/Docker.dmg) and install it.
-    
-    - Do not forget to tune up the allocated Memory and CPUs. `Docker` > `Preferences` > `Advanced`
-1. Get [Brew, Yarn & Node](https://staff.vanillaforums.com/kb/articles/135-install-node-yarn)
-1. Get [Composer](https://getcomposer.org/) and install it.
+
+   - Do not forget to tune up the allocated Memory and CPUs. `Docker` > `Preferences` > `Advanced`
+
 1. Create a directory for your project. In this example, we'll use `my-vanilla-project`, but you can use any name.
 1. Move into your project directory.
 1. Clone or download [vanilla/vanilla-docker](https://github.com/vanilla/vanilla-docker) into your project directory.
 1. Clone or download [vanilla/vanilla](https://github.com/vanilla/vanilla) into your project directory.
 1. Clone or download any other project dependencies into your project directory (for example, any of [vanilla/addons](https://github.com/vanilla/addons)), and install according to their instructions. _Note: All addons, plugins, themes, etc, must be located in the project directory. Everything outside of the project directory will not be made available inside of the Docker container._
 1. You should have the following structure
-    ```
-    my-vanilla-project
-    ├── vanilla
-    ├── vanilla-docker
-    ├── ...
-    ```
+   ```
+   my-vanilla-project
+   ├── vanilla
+   ├── vanilla-docker
+   ├── ...
+   ```
+1. Run `vanilla-docker/bin/mac-setup` which will:
+   - Install the following dependencies if not already configured.
+     - Brew
+     - PHP
+     - Composer
+     - Node
+     - Yarn
+     - docker-sync
+     - unison
+   - Configure your local machine for docker. This will prompt your for your user password.
+     - Add a self signed certificate `*.vanilla.localhost` to your keychain.
+     - Safely update your `/etc/hosts`.
+     - Add `192.0.2.1` as a loopback IP address.
+     - Create a docker volume named "datastorage" which will contain the database data.
+   - Create 2 aliases for starting and stopping vanilla-docker. These can be run from anywhere on your machine.
+     - vanilla-start
+     - vanilla-stop
 1. Move into the `vanilla` directory.
 1. Run `composer install` which will install Vanilla's dependencies.
-1. Move up and over into the `vanilla-docker` directory.
-1. Run `sudo ./mac-setup.sh` which will:
-    - Add a self signed certificate `*.vanilla.localhost` to your keychain.
-    - Safely update your `/etc/hosts`.
-    - Add `192.0.2.1` as a loopback IP address.
-    - Create a docker volume named "datastorage" which will contain the database data.
-1. Run `docker-compose up --build` (It will take a while the first time). You'll know it worked if you see something like
-    ```
-    Successfully built…
-    Successfully tagged…
-    Creating database ... done
-    Creating php-fpm  ... done
-    Creating httpd    ... done
-    Creating nginx    ... done
-    Attaching to database, php-fpm, httpd, nginx
-    …
-    php-fpm     | done.
-    ```
-    and voila -> [dev.vanilla.localhost](https://dev.vanilla.localhost/) shows the Vanilla installer.
+1. Run `vanilla-start` (It will take a while the first time). You'll know it worked if you see something like
+   ```
+   Successfully built…
+   Successfully tagged…
+   Creating database ... done
+   Creating php-fpm  ... done
+   Creating httpd    ... done
+   Creating nginx    ... done
+   Attaching to database, php-fpm, httpd, nginx
+   …
+   php-fpm     | done.
+   ```
+   and voila -> [dev.vanilla.localhost](https://dev.vanilla.localhost/) shows the Vanilla installer.
 1. Run the installer!
-    
-    - It is recommended to use `vanilla_dev` as the database name since some services are configured to use that database.
-    - It is recommended to use `database` for the host name.
-    - It is recommended to use `root` as the username.
+   - It is recommended to use `vanilla_dev` as the database name since some services are configured to use that database.
+   - It is recommended to use `database` for the host name.
+   - It is recommended to use `root` as the username.
 
-To properly stop the containers you need to run `docker-compose down`.
+### Stopping Docker
 
-Do not forget to run `docker-compose up --build` to start up the services every time you restart your computer.
+To properly stop the containers run `vanilla-stop`
+
+### Seeing logs
 
 ##### Running optional services
 
-To run additional services (named service-*.yml) you can specify which .yml file to run like so:
+To run additional services (named service-\*.yml) you can specify which .yml file to run like so:
 
 ```shell
 docker-compose -f docker-compose.yml -f docker-compose.override.yml -f service-sphinx.yml up --build
 ```
 
 You can add as many services as you want that way.
-*You can create a script named custom.boot.sh, with the combination of services that you want, so that it is easier to start the services that you want.*
+_You can create a script named custom.boot.sh, with the combination of services that you want, so that it is easier to start the services that you want._
 
 Generally, there should be documentation inside the .yml file of the service that gives you information about it.
 
@@ -163,22 +177,25 @@ docker-compose -f docker-compose.yml up --build
 This will skip `docker-compose.override.yml`. Note that by doing so you will probably have to add additional configurations to make sure that the database is reachable from the containers.
 
 To address that issue you have 2 ways of doing it:
+
 - You always have the possibility of using the loopback ip `192.0.2.1` that is installed by the `mac-setup.sh` script if your database is installed directly on your machine.
-- You can also create custom.*.yml file to extends the existing services and add extra-hosts to the services. Example:
-    `custom.dbhost.yml`
-    ```yaml
-    version: "3"
+- You can also create custom.\*.yml file to extends the existing services and add extra-hosts to the services. Example:
+  `custom.dbhost.yml`
 
-    services:
-        php-fpm:
-            extra_hosts:
-                database: 192.0.2.1
+  ```yaml
+  version: "3"
 
-    ```
-    You can then do:
-    ```shell
-    docker-compose -f docker-compose.yml -f custom.dbhost.yml up --build
-    ```
+  services:
+    php-fpm:
+      extra_hosts:
+        database: 192.0.2.1
+  ```
+
+  You can then do:
+
+  ```shell
+  docker-compose -f docker-compose.yml -f custom.dbhost.yml up --build
+  ```
 
 You can also delete the datastorage volume created by `mac-setup.sh` since you won't be using it.
 
@@ -196,4 +213,3 @@ Q. Why is everything so slow?
 
 A. You are probably running on the APFS file system that became the standard with macOS High Sierra and which has pretty bad performance with Docker for Mac.
 Having the database on your host instead of inside docker might help a lot. See [#10](https://github.com/vanilla/vanilla-docker/issues/10).
-

--- a/README.md
+++ b/README.md
@@ -149,7 +149,30 @@ _For this setup to work properly you need to clone all vanilla repositories in t
 
 To properly stop the containers run `vanilla-stop`
 
-### Seeing logs
+## Updating an existing vanilla-docker installation
+
+- Pull the latest version of `vanilla-docker`
+- Restart docker entirely.
+
+  ![image](https://user-images.githubusercontent.com/1770056/82736370-4a8f9380-9cf7-11ea-8f18-26f965e9abe1.png)
+
+- Navigate to `vanilla-docker`
+- Run `bin/mac-setup` (even if you already ran it before).
+- Run `vanilla-start` from anywhere.
+
+### Updating to a RAW data format
+
+You may see a message "It looks like your docker volume is not in the RAW format." when trying to proceed with your upgrade.
+
+In order to changer to the RAW data format for docker, you need to do the following:
+
+- Backup any databases you have.
+- Open the docker troubleshooting page. (Open docker settings, click the "Bug" icon next to settings.)
+- Click on `Reset disk image`.
+- Wait until that completes.
+- Run the setup script again.
+- Start docker `vanilla-start`.
+- Restore your databases.
 
 ##### Running optional services
 

--- a/README.md
+++ b/README.md
@@ -232,7 +232,23 @@ See [Make unit tests work within PhpStorm](./docs/unit-tests.md).
 
 ## F.A.Q
 
-Q. Why is everything so slow?
+Q. My syncronization seems to not be working.
 
-A. You are probably running on the APFS file system that became the standard with macOS High Sierra and which has pretty bad performance with Docker for Mac.
-Having the database on your host instead of inside docker might help a lot. See [#10](https://github.com/vanilla/vanilla-docker/issues/10).
+A. There are multiple reasons the sync could fail. The primary one being that you are mounting too many files into your volume. If you have files in the parent directory of vanilla-docker that are not related to _running_ vanilla, it's recommended to move these.
+
+Another reason might be mass-modification of files. If you modify 100k+ files at once, with a command like `chmod -r` or `chown -r` then you will likely need to reset your sync.
+
+These are the methods that you can use to troubleshoot, in order of fastest to slowest.
+
+- Restart vanilla-docker and docker.
+  - `vanilla-stop`
+  - Docker Menu -> Restart
+  - Wait for restart to finish...
+  - `vanilla-start`
+- Reboot your computer.
+- Reset your sync.
+  - `vanilla-stop`
+  - Docker Menu -> Restart
+  - Wait for restart to finish...
+  - `cd /path/to/vanilla-docker && docker-sync clean`
+  - `vanilla-start`

--- a/bin/mac-setup
+++ b/bin/mac-setup
@@ -16,14 +16,16 @@ SEPARATOR="==================================";
 echo "Installing Dependencies"
 echo $SEPARATOR
 
-if [ -x "$(command -v brew)" ]; then
+if [ -x "$(command -v brew)" ]
+then
     echo "Brew is already installed."
 else
     echo "Installing Brew"
     ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 fi
 
-if [ -x "$(command -v php)" ]; then
+if [ -x "$(command -v php)" ]
+then
     echo "PHP is already installed."
 else
     echo "Installing PHP"
@@ -31,7 +33,8 @@ else
     brew install php
 fi
 
-if [ -x "$(command -v composer)" ]; then
+if [ -x "$(command -v composer)" ]
+then
     echo "Composer is already installed."
 else
     echo "Installing Composer"
@@ -40,7 +43,8 @@ else
 fi
 
 
-if [ -x "$(command -v node)" ]; then
+if [ -x "$(command -v node)" ]
+then
     echo "Node is already installed."
 else
     echo "Installing Node"
@@ -48,7 +52,8 @@ else
     brew install node@12
 fi
 
-if [ -x "$(command -v yarn)" ]; then
+if [ -x "$(command -v yarn)" ]
+then
     echo "Yarn is already installed."
 else
     echo "Installing Yarn"
@@ -56,7 +61,8 @@ else
     npm i -g yarn
 fi
 
-if [ -x "$(command -v unison)" ]; then
+if [ -x "$(command -v unison)" ]
+then
     echo "Unison is already installed."
 else
     echo "Installing Unison"
@@ -64,12 +70,57 @@ else
     brew install unison
 fi
 
-if [ -x "$(command -v docker-sync)" ]; then
+# # there are some issues with version of ruby that aren't from brew.
+# if [[ $(which ruby) == "/usr/bin/ruby" ]]
+# then
+#     echo "The system version of ruby is all that has been found."
+#     echo "This is insufficient for vanilla-docker so a version from brew will be installed"
+#     echo $SEPARATOR
+#     brew install ruby
+# elif [ -x "$(command -v ruby)" ]
+# then
+#     echo "Ruby is already installed."
+# else
+#     echo "Installing ruby"
+#     echo $SEPARATOR
+#     brew install ruby
+# fi
+
+if [ -x "$(command -v docker-sync)" ]
+then
     echo "Docker-sync is already installed."
 else
     echo "Installing Docker-sync"
     echo $SEPARATOR
-    gem install --user-install docker-sync
+    gem install --install-dir /usr/local/bin docker-sync
+fi
+
+if ! [ -x "$(command -v docker-sync)" ]
+then
+    PATH_CMD="export PATH=\"\$(ruby -r rubygems -e 'puts Gem.user_dir')/bin:\$PATH\""
+
+    echo "Adding Rubygems to your PATH"
+    echo ""
+    echo ""
+    echo $SEPARATOR
+    echo ""
+    echo "You will need to restart you terminal after this"
+    echo ""
+    echo $SEPARATOR
+    echo ""
+    echo ""
+
+    eval "$PATH_CMD"
+    touch "$HOME/.bash_profile"
+    touch "$HOME/.zshenv"
+    grep -qF -- "$PATH_CMD" "$HOME/.bash_profile" || echo "$PATH_CMD" >> "$HOME/.bash_profile"
+    echo "$PATH_CMD" >> "$HOME/.zshenv"
+
+    if [ -x "$(command -v fish)" ]
+    then
+        echo "set RUBY_GEM_PATH (ruby -r rubygems -e 'puts Gem.user_dir')/bin" >> "$HOME/.config/fish/config.fish"
+        echo "set -gx PATH \$RUBY_GEM_PATH \$PATH" >> "$HOME/.config/fish/config.fish"
+    fi
 fi
 
 echo "Configuring Locale Certificates"

--- a/bin/mac-setup
+++ b/bin/mac-setup
@@ -3,7 +3,7 @@
 # Upgrade check
 
 DOCKER_RAW_DOCKER_PATH="/$HOME/Library/Containers/com.docker.docker/Data/vms/0/Docker.raw"
-DOCKER_RAW_DATA_PATH="/$HOME/Library/Containers/com.docker.docker/Data/vms/0/Data.raw"
+DOCKER_RAW_DATA_PATH="/$HOME/Library/Containers/com.docker.docker/Data/vms/0/data/Docker.raw"
 if [ ! -f "$DOCKER_RAW_DOCKER_PATH" ] && [ ! -f "$DOCKER_RAW_DATA_PATH" ]
 then
     echo "It looks like your docker volume is not in the RAW format."

--- a/bin/mac-setup
+++ b/bin/mac-setup
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+
+ORIG_PWD=$(pwd)
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+
+DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
+VANILLA_DOCKER=$(dirname "$DIR")
+
+SEPARATOR="==================================";
+
+echo "Installing Dependencies"
+echo $SEPARATOR
+
+if [ -x "$(command -v brew)" ]; then
+    echo "Brew is already installed."
+else
+    echo "Installing Brew"
+    ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+fi
+
+if [ -x "$(command -v php)" ]; then
+    echo "PHP is already installed."
+else
+    echo "Installing PHP"
+    echo $SEPARATOR
+    brew install php
+fi
+
+if [ -x "$(command -v composer)" ]; then
+    echo "Composer is already installed."
+else
+    echo "Installing Composer"
+    echo $SEPARATOR
+    brew install composer
+fi
+
+
+if [ -x "$(command -v node)" ]; then
+    echo "Node is already installed."
+else
+    echo "Installing Node"
+    echo $SEPARATOR
+    brew install node@12
+fi
+
+if [ -x "$(command -v yarn)" ]; then
+    echo "Yarn is already installed."
+else
+    echo "Installing Yarn"
+    echo $SEPARATOR
+    npm i -g yarn
+fi
+
+if [ -x "$(command -v unison)" ]; then
+    echo "Unison is already installed."
+else
+    echo "Installing Unison"
+    echo $SEPARATOR
+    brew install unison
+fi
+
+if [ -x "$(command -v docker-sync)" ]; then
+    echo "Docker-sync is already installed."
+else
+    echo "Installing Docker-sync"
+    echo $SEPARATOR
+    gem install --user-install docker-sync
+fi
+
+echo "Configuring Locale Certificates"
+echo $SEPARATOR
+echo "You will be prompted for your administrator password to proceed."
+sudo "$VANILLA_DOCKER/mac-setup-root"
+
+echo "Symlinking Easy-Access Commands"
+echo $SEPARATOR
+ln -sf "$VANILLA_DOCKER/bin/start" /usr/local/bin/vanilla-start
+ln -sf "$VANILLA_DOCKER/bin/stop" /usr/local/bin/vanilla-stop
+
+echo "New Commands:"
+echo "vanilla-start"
+echo "vanilla-stop"

--- a/bin/mac-setup
+++ b/bin/mac-setup
@@ -126,7 +126,7 @@ fi
 echo "Configuring Locale Certificates"
 echo $SEPARATOR
 echo "You will be prompted for your administrator password to proceed."
-sudo "$VANILLA_DOCKER/mac-setup-root"
+sudo "$VANILLA_DOCKER/bin/mac-setup-root"
 
 echo "Symlinking Easy-Access Commands"
 echo $SEPARATOR

--- a/bin/mac-setup
+++ b/bin/mac-setup
@@ -1,5 +1,21 @@
 #!/usr/bin/env bash
 
+# Upgrade check
+
+DOCKER_RAW_DOCKER_PATH="/$HOME/Library/Containers/com.docker.docker/Data/vms/0/Docker.raw"
+DOCKER_RAW_DATA_PATH="/$HOME/Library/Containers/com.docker.docker/Data/vms/0/Data.raw"
+if [ ! -f "$DOCKER_RAW_DOCKER_PATH" ] && [ ! -f "$DOCKER_RAW_DATA_PATH" ]
+then
+    echo "It looks like your docker volume is not in the RAW format."
+    echo "This can cause instability and issues with the latest version of vanilla-docker".
+    echo "In order to fix this, see the upgrade guide."
+    echo ""
+    echo "https://github.com/vanilla/vanilla-docker/tree/master/README.md#updating-to-a-raw-data-format"
+    exit 1;
+fi
+
+# Path restoration
+
 ORIG_PWD=$(pwd)
 SOURCE="${BASH_SOURCE[0]}"
 while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink

--- a/bin/mac-setup-root
+++ b/bin/mac-setup-root
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+if [[ $UID != 0 ]]; then
+    echo "Please run this script with sudo:";
+    echo "sudo $0 $*";
+    exit 1;
+fi
+
 HOSTNAMES=(
     advanced-embed.vanilla.localhost
     database
@@ -10,12 +16,6 @@ HOSTNAMES=(
     sso.vanilla.localhost
     vanilla.test
 );
-
-if [[ $UID != 0 ]]; then
-    echo "Please run this script with sudo:";
-    echo "sudo $0 $*";
-    exit 1;
-fi
 
 DOCKER_CHECK=$(command -v docker);
 if [ ! -n "$DOCKER_CHECK" ]; then

--- a/bin/start
+++ b/bin/start
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+ORIG_PWD=$(pwd)
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+
+DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
+VANILLA_DOCKER=$(dirname "$DIR")
+cd $VANILLA_DOCKER
+
+echo "Starting file synchronization. This may take a while the first time you run it."
+echo "=========================="
+docker-sync start
+
+echo "";
+echo "Starting vanilla-docker"
+echo "=========================="
+docker-compose \
+-f "$VANILLA_DOCKER/docker-compose.yml" \
+-f "$VANILLA_DOCKER/docker-compose.override.yml" \
+-f "$VANILLA_DOCKER/service-sphinx.yml" \
+-f "$VANILLA_DOCKER/service-memcached.yml" \
+-f "$VANILLA_DOCKER/docker-compose.sync.yml" \
+up --remove-orphans --build -d
+
+cd $ORIG_PWD

--- a/bin/start
+++ b/bin/start
@@ -29,6 +29,8 @@ Looking for changes"
 echo ""
 echo "Proceed anyways. I promise it's worth the wait."
 echo "Subsequent starts should be faster."
+echo ""
+echo "It is recommended not to modify in any source code files during this first sync."
 echo "=========================================="
 echo ""
 docker-sync start

--- a/bin/start
+++ b/bin/start
@@ -12,13 +12,25 @@ DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
 VANILLA_DOCKER=$(dirname "$DIR")
 cd $VANILLA_DOCKER
 
-echo "Starting file synchronization. This may take a while the first time you run it."
-echo "=========================="
+echo "Starting File Sync Service"
+echo "Note this may take a while the first time."
+echo "In particular it may take a while on something like this"
+echo ""
+echo "doing initial sync with unison
+Unison 2.51.2 (ocaml 4.06.1): Contacting server...
+Looking for changes"
+echo ""
+echo "Proceed anyways. I promise it's worth the wait."
+echo "Subsequent starts should be faster."
+echo "=========================================="
+echo ""
 docker-sync start
 
 echo "";
 echo "Starting vanilla-docker"
 echo "=========================="
+echo ""
+
 docker-compose \
 -f "$VANILLA_DOCKER/docker-compose.yml" \
 -f "$VANILLA_DOCKER/docker-compose.override.yml" \

--- a/bin/start
+++ b/bin/start
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+DATA_STORAGE_CHECK=$(docker volume ls -q | grep datastorage);
+
+if [ ! -n "$DATA_STORAGE_CHECK" ]; then
+    echo "Looks like the data storage volume isn't configured. Did you forget to run the setup script?"
+    exit 1;
+fi
+
 ORIG_PWD=$(pwd)
 SOURCE="${BASH_SOURCE[0]}"
 while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink

--- a/bin/stop
+++ b/bin/stop
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+ORIG_PWD=$(pwd)
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+
+DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
+VANILLA_DOCKER=$(dirname "$DIR")
+
+cd $VANILLA_DOCKER
+
+# docker-sync start
+docker-compose \
+-f "$VANILLA_DOCKER/docker-compose.yml" \
+-f "$VANILLA_DOCKER/docker-compose.override.yml" \
+-f "$VANILLA_DOCKER/service-sphinx.yml" \
+-f "$VANILLA_DOCKER/service-memcached.yml" \
+-f "$VANILLA_DOCKER/docker-compose.sync.yml" \
+down
+
+docker-sync stop
+cd $ORIG_PWD

--- a/bootstrap.before.php
+++ b/bootstrap.before.php
@@ -6,7 +6,7 @@ require_once __DIR__ . "/resources/sphinx/sphinxapi.php";
  * This file will make Vanilla use a different config depending on folder you're on.
  */
 call_user_func(function () {
-    $host = $_SERVER['HTTP_HOST'];
+    $host = $_SERVER['HTTP_HOST'] ?? 'default';
     [$host, $port] = explode(':', $host, 2) + ['', ''];
 
     // Whitelist to a domain. This can probably get removed at some point.

--- a/docker-compose.sync.yml
+++ b/docker-compose.sync.yml
@@ -1,0 +1,19 @@
+# this is our development docker-compose building on top of the production docker-compose, just mounting
+# the sync image - not redefining anything else
+
+version: "3.5"
+services:
+  php-fpm:
+    volumes:
+      - app-code-sync:/srv/vanilla-repositories:nocopy # nocopy is important
+  nginx:
+    volumes:
+      - app-code-sync:/srv/vanilla-repositories:nocopy # nocopy is important
+  httpd:
+    volumes:
+      - app-code-sync:/srv/vanilla-repositories:nocopy # nocopy is important
+
+# that the important thing
+volumes:
+  app-code-sync:
+    external: true

--- a/docker-sync.yml
+++ b/docker-sync.yml
@@ -21,3 +21,6 @@ syncs:
 
     # optional: use this to change how many consecutive times high cpu usage must be observed before unison is restarted
     monit_high_cpu_cycles: 2
+
+    # Map the user to "www-data" which defaults to 33 on Ubunto.
+    sync_userid: '33'

--- a/docker-sync.yml
+++ b/docker-sync.yml
@@ -1,9 +1,23 @@
 version: "2"
 
 options:
+  compose-file-path:
+    - "docker-compose.yml"
+    - "docker-compose.override.yml"
+    - "service-memcached.yml"
+    - "service-sphinx.yml"
+  compose-dev-file-path: 'docker-compose.sync.yml'
   verbose: true
 syncs:
   app-code-sync: # tip: add -sync and you keep consistent names as a convention
     src: '../'
-    # sync_strategy: 'native_osx' # not needed, this is the default now
-    sync_excludes: ['vanilla-docker', '*/.git', '*/node_modules', '*/bower_components']
+    watch_excludes: ['*/.docker-sync', '*/.git', '*/node_modules', '*/bower_components']
+    sync_excludes: ['*/.docker-sync', '*/.git', '*/node_modules', '*/bower_components']
+    # optional: use this to switch monit monitoring on
+    monit_enable: true
+
+    # optional: use this to change how many seconds between each monit check (cycle)
+    monit_interval: 5
+
+    # optional: use this to change how many consecutive times high cpu usage must be observed before unison is restarted
+    monit_high_cpu_cycles: 2

--- a/docker-sync.yml
+++ b/docker-sync.yml
@@ -1,0 +1,9 @@
+version: "2"
+
+options:
+  verbose: true
+syncs:
+  app-code-sync: # tip: add -sync and you keep consistent names as a convention
+    src: '../'
+    # sync_strategy: 'native_osx' # not needed, this is the default now
+    sync_excludes: ['vanilla-docker', '*/.git', '*/node_modules', '*/bower_components']

--- a/resources/usr/local/etc/sphinx/configs-available/everything.sphinx.conf
+++ b/resources/usr/local/etc/sphinx/configs-available/everything.sphinx.conf
@@ -1,3 +1,325 @@
+index Base_Charsets {
+  morphology = none
+  stopwords = /var/data/searchd/stops.txt
+
+  # Support the following charsets in the following order:
+  # (Each sets separated by new lines)
+  #
+  #   Latin (English, French, Spanish, ...)
+  #   Latin Accent Folding (A)
+  #   ...
+  #   Latin Accent Folding (Z)
+  #   Latin Extras
+  #   Arabic
+  #   Armenian
+  #   Bengali
+  #   Cyrillic (Russian)
+  #   CJK (Basic support, no duplicated ideogram mappings)
+  #   Devanagari (Hindi)
+  #   Georgian
+  #   Greek
+  #   Gujarati
+  #   Kannada
+  #   Malayalam
+  #   Tamil
+  #   Thai
+  #
+  # Mostly pulled from http://sphinxsearch.com/wiki/doku.php?id=charset_tables
+  #
+  charset_table = 0..9, A..Z->a..z, _, a..z, -, \
+        \
+        \
+        U+00C0->a, U+00C1->a, U+00C2->a, U+00C3->a, U+00C4->a, U+00C5->a, U+00E0->a, \
+        U+00E1->a, U+00E2->a, U+00E3->a, U+00E4->a, U+00E5->a, U+0100->a, U+0101->a, \
+        U+0102->a, U+0103->a, U+010300->a, U+0104->a, U+0105->a, U+01CD->a, U+01CE->a, \
+        U+01DE->a, U+01DF->a, U+01E0->a, U+01E1->a, U+01FA->a, U+01FB->a, U+0200->a, \
+        U+0201->a, U+0202->a, U+0203->a, U+0226->a, U+0227->a, U+023A->a, U+0250->a, \
+        U+04D0->a, U+04D1->a, U+1D2C->a, U+1D43->a, U+1D44->a, U+1D8F->a, U+1E00->a, \
+        U+1E01->a, U+1E9A->a, U+1EA0->a, U+1EA1->a, U+1EA2->a, U+1EA3->a, U+1EA4->a, \
+        U+1EA5->a, U+1EA6->a, U+1EA7->a, U+1EA8->a, U+1EA9->a, U+1EAA->a, U+1EAB->a, \
+        U+1EAC->a, U+1EAD->a, U+1EAE->a, U+1EAF->a, U+1EB0->a, U+1EB1->a, U+1EB2->a, \
+        U+1EB3->a, U+1EB4->a, U+1EB5->a, U+1EB6->a, U+1EB7->a, U+2090->a, U+2C65->a, \
+        \
+        \
+        U+0180->b, U+0181->b, U+0182->b, U+0183->b, U+0243->b, U+0253->b, U+0299->b, \
+        U+16D2->b, U+1D03->b, U+1D2E->b, U+1D2F->b, U+1D47->b, U+1D6C->b, U+1D80->b, \
+        U+1E02->b, U+1E03->b, U+1E04->b, U+1E05->b, U+1E06->b, U+1E07->b, \
+        \
+        \
+        U+00C7->c, U+00E7->c, U+0106->c, U+0107->c, U+0108->c, U+0109->c, U+010A->c, \
+        U+010B->c, U+010C->c, U+010D->c, U+0187->c, U+0188->c, U+023B->c, U+023C->c, \
+        U+0255->c, U+0297->c, U+1D9C->c, U+1D9D->c, U+1E08->c, U+1E09->c, U+212D->c, \
+        U+2184->c, \
+        \
+        \
+        U+010E->d, U+010F->d, U+0110->d, U+0111->d, U+0189->d, U+018A->d, U+018B->d, \
+        U+018C->d, U+01C5->d, U+01F2->d, U+0221->d, U+0256->d, U+0257->d, U+1D05->d, \
+        U+1D30->d, U+1D48->d, U+1D6D->d, U+1D81->d, U+1D91->d, U+1E0A->d, U+1E0B->d, \
+        U+1E0C->d, U+1E0D->d, U+1E0E->d, U+1E0F->d, U+1E10->d, U+1E11->d, U+1E12->d, \
+        U+1E13->d, \
+        \
+        \
+        U+00C8->e, U+00C9->e, U+00CA->e, U+00CB->e, U+00E8->e, U+00E9->e, U+00EA->e, \
+        U+00EB->e, U+0112->e, U+0113->e, U+0114->e, U+0115->e, U+0116->e, U+0117->e, \
+        U+0118->e, U+0119->e, U+011A->e, U+011B->e, U+018E->e, U+0190->e, U+01DD->e, \
+        U+0204->e, U+0205->e, U+0206->e, U+0207->e, U+0228->e, U+0229->e, U+0246->e, \
+        U+0247->e, U+0258->e, U+025B->e, U+025C->e, U+025D->e, U+025E->e, U+029A->e, \
+        U+1D07->e, U+1D08->e, U+1D31->e, U+1D32->e, U+1D49->e, U+1D4B->e, U+1D4C->e, \
+        U+1D92->e, U+1D93->e, U+1D94->e, U+1D9F->e, U+1E14->e, U+1E15->e, U+1E16->e, \
+        U+1E17->e, U+1E18->e, U+1E19->e, U+1E1A->e, U+1E1B->e, U+1E1C->e, U+1E1D->e, \
+        U+1EB8->e, U+1EB9->e, U+1EBA->e, U+1EBB->e, U+1EBC->e, U+1EBD->e, U+1EBE->e, \
+        U+1EBF->e, U+1EC0->e, U+1EC1->e, U+1EC2->e, U+1EC3->e, U+1EC4->e, U+1EC5->e, \
+        U+1EC6->e, U+1EC7->e, U+2091->e, \
+        \
+        \
+        U+0191->f, U+0192->f, U+1D6E->f, U+1D82->f, U+1DA0->f, U+1E1E->f, U+1E1F->f, \
+        \
+        \
+        U+011C->g, U+011D->g, U+011E->g, U+011F->g, U+0120->g, U+0121->g, U+0122->g, \
+        U+0123->g, U+0193->g, U+01E4->g, U+01E5->g, U+01E6->g, U+01E7->g, U+01F4->g, \
+        U+01F5->g, U+0260->g, U+0261->g, U+0262->g, U+029B->g, U+1D33->g, U+1D4D->g, \
+        U+1D77->g, U+1D79->g, U+1D83->g, U+1DA2->g, U+1E20->g, U+1E21->g, \
+        \
+        \
+        U+0124->h, U+0125->h, U+0126->h, U+0127->h, U+021E->h, U+021F->h, U+0265->h, \
+        U+0266->h, U+029C->h, U+02AE->h, U+02AF->h, U+02B0->h, U+02B1->h, U+1D34->h, \
+        U+1DA3->h, U+1E22->h, U+1E23->h, U+1E24->h, U+1E25->h, U+1E26->h, U+1E27->h, \
+        U+1E28->h, U+1E29->h, U+1E2A->h, U+1E2B->h, U+1E96->h, U+210C->h, U+2C67->h, \
+        U+2C68->h, U+2C75->h, U+2C76->h, \
+        \
+        \
+        U+00CC->i, U+00CD->i, U+00CE->i, U+00CF->i, U+00EC->i, U+00ED->i, U+00EE->i, \
+        U+00EF->i, U+010309->i, U+0128->i, U+0129->i, U+012A->i, U+012B->i, U+012C->i, \
+        U+012D->i, U+012E->i, U+012F->i, U+0130->i, U+0131->i, U+0197->i, U+01CF->i, \
+        U+01D0->i, U+0208->i, U+0209->i, U+020A->i, U+020B->i, U+0268->i, U+026A->i, \
+        U+040D->i, U+0418->i, U+0419->i, U+0438->i, U+0439->i, U+0456->i, U+1D09->i, \
+        U+1D35->i, U+1D4E->i, U+1D62->i, U+1D7B->i, U+1D96->i, U+1DA4->i, U+1DA6->i, \
+        U+1DA7->i, U+1E2C->i, U+1E2D->i, U+1E2E->i, U+1E2F->i, U+1EC8->i, U+1EC9->i, \
+        U+1ECA->i, U+1ECB->i, U+2071->i, U+2111->i, \
+        \
+        \
+        U+0134->j, U+0135->j, U+01C8->j, U+01CB->j, U+01F0->j, U+0237->j, U+0248->j, \
+        U+0249->j, U+025F->j, U+0284->j, U+029D->j, U+02B2->j, U+1D0A->j, U+1D36->j, \
+        U+1DA1->j, U+1DA8->j, \
+        \
+        \
+        U+0136->k, U+0137->k, U+0198->k, U+0199->k, U+01E8->k, U+01E9->k, U+029E->k, \
+        U+1D0B->k, U+1D37->k, U+1D4F->k, U+1D84->k, U+1E30->k, U+1E31->k, U+1E32->k, \
+        U+1E33->k, U+1E34->k, U+1E35->k, U+2C69->k, U+2C6A->k, \
+        \
+        \
+        U+0139->l, U+013A->l, U+013B->l, U+013C->l, U+013D->l, U+013E->l, U+013F->l, \
+        U+0140->l, U+0141->l, U+0142->l, U+019A->l, U+01C8->l, U+0234->l, U+023D->l, \
+        U+026B->l, U+026C->l, U+026D->l, U+029F->l, U+02E1->l, U+1D0C->l, U+1D38->l, \
+        U+1D85->l, U+1DA9->l, U+1DAA->l, U+1DAB->l, U+1E36->l, U+1E37->l, U+1E38->l, \
+        U+1E39->l, U+1E3A->l, U+1E3B->l, U+1E3C->l, U+1E3D->l, U+2C60->l, U+2C61->l, \
+        U+2C62->l, \
+        \
+        \
+        U+019C->m, U+026F->m, U+0270->m, U+0271->m, U+1D0D->m, U+1D1F->m, U+1D39->m, \
+        U+1D50->m, U+1D5A->m, U+1D6F->m, U+1D86->m, U+1DAC->m, U+1DAD->m, U+1E3E->m, \
+        U+1E3F->m, U+1E40->m, U+1E41->m, U+1E42->m, U+1E43->m, \
+        \
+        \
+        U+00D1->n, U+00F1->n, U+0143->n, U+0144->n, U+0145->n, U+0146->n, U+0147->n, \
+        U+0148->n, U+0149->n, U+019D->n, U+019E->n, U+01CB->n, U+01F8->n, U+01F9->n, \
+        U+0220->n, U+0235->n, U+0272->n, U+0273->n, U+0274->n, U+1D0E->n, U+1D3A->n, \
+        U+1D3B->n, U+1D70->n, U+1D87->n, U+1DAE->n, U+1DAF->n, U+1DB0->n, U+1E44->n, \
+        U+1E45->n, U+1E46->n, U+1E47->n, U+1E48->n, U+1E49->n, U+1E4A->n, U+1E4B->n, \
+        U+207F->n, \
+        \
+        \
+        U+00D2->o, U+00D3->o, U+00D4->o, U+00D5->o, U+00D6->o, U+00D8->o, U+00F2->o, \
+        U+00F3->o, U+00F4->o, U+00F5->o, U+00F6->o, U+00F8->o, U+01030F->o, U+014C->o, \
+        U+014D->o, U+014E->o, U+014F->o, U+0150->o, U+0151->o, U+0186->o, U+019F->o, \
+        U+01A0->o, U+01A1->o, U+01D1->o, U+01D2->o, U+01EA->o, U+01EB->o, U+01EC->o, \
+        U+01ED->o, U+01FE->o, U+01FF->o, U+020C->o, U+020D->o, U+020E->o, U+020F->o, \
+        U+022A->o, U+022B->o, U+022C->o, U+022D->o, U+022E->o, U+022F->o, U+0230->o, \
+        U+0231->o, U+0254->o, U+0275->o, U+043E->o, U+04E6->o, U+04E7->o, U+04E8->o, \
+        U+04E9->o, U+04EA->o, U+04EB->o, U+1D0F->o, U+1D10->o, U+1D11->o, U+1D12->o, \
+        U+1D13->o, U+1D16->o, U+1D17->o, U+1D3C->o, U+1D52->o, U+1D53->o, U+1D54->o, \
+        U+1D55->o, U+1D97->o, U+1DB1->o, U+1E4C->o, U+1E4D->o, U+1E4E->o, U+1E4F->o, \
+        U+1E50->o, U+1E51->o, U+1E52->o, U+1E53->o, U+1ECC->o, U+1ECD->o, U+1ECE->o, \
+        U+1ECF->o, U+1ED0->o, U+1ED1->o, U+1ED2->o, U+1ED3->o, U+1ED4->o, U+1ED5->o, \
+        U+1ED6->o, U+1ED7->o, U+1ED8->o, U+1ED9->o, U+1EDA->o, U+1EDB->o, U+1EDC->o, \
+        U+1EDD->o, U+1EDE->o, U+1EDF->o, U+1EE0->o, U+1EE1->o, U+1EE2->o, U+1EE3->o, \
+        U+2092->o, U+2C9E->o, U+2C9F->o, \
+        \
+        \
+        U+01A4->p, U+01A5->p, U+1D18->p, U+1D3E->p, U+1D56->p, U+1D71->p, U+1D7D->p, \
+        U+1D88->p, U+1E54->p, U+1E55->p, U+1E56->p, U+1E57->p, U+2C63->p, \
+        \
+        \
+        U+024A->q, U+024B->q, U+02A0->q, \
+        \
+        \
+        U+0154->r, U+0155->r, U+0156->r, U+0157->r, U+0158->r, U+0159->r, U+0210->r, \
+        U+0211->r, U+0212->r, U+0213->r, U+024C->r, U+024D->r, U+0279->r, U+027A->r, \
+        U+027B->r, U+027C->r, U+027D->r, U+027E->r, U+027F->r, U+0280->r, U+0281->r, \
+        U+02B3->r, U+02B4->r, U+02B5->r, U+02B6->r, U+1D19->r, U+1D1A->r, U+1D3F->r, \
+        U+1D63->r, U+1D72->r, U+1D73->r, U+1D89->r, U+1DCA->r, U+1E58->r, U+1E59->r, \
+        U+1E5A->r, U+1E5B->r, U+1E5C->r, U+1E5D->r, U+1E5E->r, U+1E5F->r, U+211C->r, \
+        U+2C64->r, \
+        \
+        \
+        U+00DF->s, U+015A->s, U+015B->s, U+015C->s, U+015D->s, U+015E->s, U+015F->s, \
+        U+0160->s, U+0161->s, U+017F->s, U+0218->s, U+0219->s, U+023F->s, U+0282->s, \
+        U+02E2->s, U+1D74->s, U+1D8A->s, U+1DB3->s, U+1E60->s, U+1E61->s, U+1E62->s, \
+        U+1E63->s, U+1E64->s, U+1E65->s, U+1E66->s, U+1E67->s, U+1E68->s, U+1E69->s, \
+        U+1E9B->s, \
+        \
+        \
+        U+0162->t, U+0163->t, U+0164->t, U+0165->t, U+0166->t, U+0167->t, U+01AB->t, \
+        U+01AC->t, U+01AD->t, U+01AE->t, U+021A->t, U+021B->t, U+0236->t, U+023E->t, \
+        U+0287->t, U+0288->t, U+1D1B->t, U+1D40->t, U+1D57->t, U+1D75->t, U+1DB5->t, \
+        U+1E6A->t, U+1E6B->t, U+1E6C->t, U+1E6D->t, U+1E6E->t, U+1E6F->t, U+1E70->t, \
+        U+1E71->t, U+1E97->t, U+2C66->t, \
+        \
+        \
+        U+00D9->u, U+00DA->u, U+00DB->u, U+00DC->u, U+00F9->u, U+00FA->u, U+00FB->u, \
+        U+00FC->u, U+010316->u, U+0168->u, U+0169->u, U+016A->u, U+016B->u, U+016C->u, \
+        U+016D->u, U+016E->u, U+016F->u, U+0170->u, U+0171->u, U+0172->u, U+0173->u, \
+        U+01AF->u, U+01B0->u, U+01D3->u, U+01D4->u, U+01D5->u, U+01D6->u, U+01D7->u, \
+        U+01D8->u, U+01D9->u, U+01DA->u, U+01DB->u, U+01DC->u, U+0214->u, U+0215->u, \
+        U+0216->u, U+0217->u, U+0244->u, U+0289->u, U+1D1C->u, U+1D1D->u, U+1D1E->u, \
+        U+1D41->u, U+1D58->u, U+1D59->u, U+1D64->u, U+1D7E->u, U+1D99->u, U+1DB6->u, \
+        U+1DB8->u, U+1E72->u, U+1E73->u, U+1E74->u, U+1E75->u, U+1E76->u, U+1E77->u, \
+        U+1E78->u, U+1E79->u, U+1E7A->u, U+1E7B->u, U+1EE4->u, U+1EE5->u, U+1EE6->u, \
+        U+1EE7->u, U+1EE8->u, U+1EE9->u, U+1EEA->u, U+1EEB->u, U+1EEC->u, U+1EED->u, \
+        U+1EEE->u, U+1EEF->u, U+1EF0->u, U+1EF1->u, \
+        \
+        \
+        U+01B2->v, U+0245->v, U+028B->v, U+028C->v, U+1D20->v, U+1D5B->v, U+1D65->v, \
+        U+1D8C->v, U+1DB9->v, U+1DBA->v, U+1E7C->v, U+1E7D->v, U+1E7E->v, U+1E7F->v, \
+        U+2C74->v, \
+        \
+        \
+        U+0174->w, U+0175->w, U+028D->w, U+02B7->w, U+1D21->w, U+1D42->w, U+1E80->w, \
+        U+1E81->w, U+1E82->w, U+1E83->w, U+1E84->w, U+1E85->w, U+1E86->w, U+1E87->w, \
+        U+1E88->w, U+1E89->w, U+1E98->w, \
+        \
+        \
+        U+02E3->x, U+1D8D->x, U+1E8A->x, U+1E8B->x, U+1E8C->x, U+1E8D->x, U+2093->x, \
+        \
+        \
+        U+00DD->y, U+00FD->y, U+00FF->y, U+0176->y, U+0177->y, U+0178->y, U+01B3->y, \
+        U+01B4->y, U+0232->y, U+0233->y, U+024E->y, U+024F->y, U+028E->y, U+028F->y, \
+        U+02B8->y, U+1E8E->y, U+1E8F->y, U+1E99->y, U+1EF2->y, U+1EF3->y, U+1EF4->y, \
+        U+1EF5->y, U+1EF6->y, U+1EF7->y, U+1EF8->y, U+1EF9->y, \
+        \
+        \
+        U+0179->z, U+017A->z, U+017B->z, U+017C->z, U+017D->z, U+017E->z, U+01B5->z, \
+        U+01B6->z, U+0224->z, U+0225->z, U+0240->z, U+0290->z, U+0291->z, U+1D22->z, \
+        U+1D76->z, U+1D8E->z, U+1DBB->z, U+1DBC->z, U+1DBD->z, U+1E90->z, U+1E91->z, \
+        U+1E92->z, U+1E93->z, U+1E94->z, U+1E95->z, U+2128->z, U+2C6B->z, U+2C6C->z, \
+        \
+        \
+        U+00C6->U+00E6, U+01E2->U+00E6, U+01E3->U+00E6, U+01FC->U+00E6, U+01FD->U+00E6, \
+        U+1D01->U+00E6, U+1D02->U+00E6, U+1D2D->U+00E6, U+1D46->U+00E6, U+00E6, \
+        U+0152->U+0153, U+0153, \
+        \
+        \
+        U+0626,U+0627..U+063A,U+0641..U+064A,U+0679,U+067E,U+0686,U+0688,U+0691,U+0698,U+06AF,U+06BA, \
+        U+06BB,U+0660..U+0669->0..9,U+06F0..U+06F9->0..9, U+0622->U+0627, \
+        U+0623->U+0627, U+0625->U+0627, U+0671->U+0627, U+0672->U+0627, U+0673->U+0627, \
+        U+0675->U+0627, U+066E->U+0628, U+067B->U+0628, U+0680->U+0628, U+06C0->U+0629, \
+        U+06C1->U+0629, U+06C2->U+0629, U+06C3->U+0629, U+067A->U+062A, U+067B->U+062A, \
+        U+067C->U+062A, U+067D->U+062A, U+067F->U+062A, U+0680->U+062A, U+0681->U+062D, \
+        U+0682->U+062D, U+0683->U+062D, U+0684->U+062D, U+0685->U+062D, U+0687->U+0686, \
+        U+06BF->U+0686, U+0689->U+062F, U+068A->U+062F, U+068C->U+062F, U+068D->U+062F, \
+        U+068E->U+062F, U+068F->U+062F, U+0690->U+062F, U+06EE->U+062F, U+068B->U+0688, \
+        U+0692->U+0631, U+0693->U+0631, U+0694->U+0631, U+0695->U+0631, U+0696->U+0631, \
+        U+0697->U+0631, U+0699->U+0631, U+06EF->U+0631, U+069A->U+0633, U+069B->U+0633, \
+        U+069C->U+0633, U+06FA->U+0633, U+069D->U+0635, U+069E->U+0635, U+06FB->U+0635, \
+        U+069F->U+0637, U+06A0->U+0639, U+06FC->U+0639, U+06A1->U+0641, U+06A2->U+0641, \
+        U+06A3->U+0641, U+06A4->U+0641, U+06A5->U+0641, U+06A6->U+0641, U+066F->U+0642, \
+        U+06A7->U+0642, U+06A8->U+0642, U+063B->U+0643, U+063C->U+0643, U+06A9->U+0643, \
+        U+06AA->U+0643, U+06AB->U+0643, U+06AC->U+0643, U+06AD->U+0643, U+06AE->U+0643, \
+        U+06B0->U+06AF, U+06B1->U+06AF, U+06B2->U+06AF, U+06B3->U+06AF, U+06B4->U+06AF, \
+        U+06B5->U+0644, U+06B6->U+0644, U+06B7->U+0644, U+06B8->U+0644, U+06FE->U+0645, \
+        U+06B9->U+0646, U+06BC->U+0646, U+06BD->U+0646, U+06BE->U+0647, U+06C0->U+0647, \
+        U+06C1->U+0647, U+06C2->U+0647, U+06C3->U+0647, U+06D5->U+0647, U+06FF->U+0647, \
+        U+06C4->U+0648, U+06C5->U+0648, U+06C6->U+0648, U+06C7->U+0648, U+06C8->U+0648, \
+        U+06C9->U+0648, U+06CA->U+0648, U+06CB->U+0648, U+06CF->U+0648, U+063D->U+064A, \
+        U+063E->U+064A, U+063F->U+064A, U+06CC->U+064A, U+06CD->U+064A, U+06CE->U+064A, \
+        U+06D0->U+064A, U+06D1->U+064A, U+06D2->U+064A, U+06D3->U+064A, \
+        \
+        \
+        U+0531..U+0556->U+0561..U+0586, U+0561..U+0586, U+0587, \
+        \
+        \
+        U+09DC->U+09A1, U+09DD->U+09A2, U+09DF->U+09AF, U+09F0->U+09AC, U+09F1->U+09AC, \
+        U+0981..U+0983, U+0985..U+098C, U+098F..U+0990, U+0993..U+09A8, U+09AA..U+09B0, \
+        U+09B2, U+09B6..U+09B9, U+09BC..U+09C4, U+09C7..U+09C8, U+09CB..U+09CE, U+09D7, \
+        U+09DC, U+09DD, U+09DF, U+09E0..U+09E3, U+09E6..U+09EF, U+09F0..U+09FB, \
+        \
+        \
+        U+410..U+42F->U+430..U+44F, U+430..U+44F, U+401->U+451, U+451, \
+        \
+        \
+        U+2F00..U+2FDF, U+3040, U+3042, U+3044, U+3046, U+3048, U+30A0, U+30A2, U+30A4, \
+        U+30A6, U+30A8, U+30FF, U+3130..U+318F, U+F900..U+FA0D, U+FA10, U+FA12, U+FA15..U+FA1E, \
+        U+FA20, U+FA22, U+FA25, U+FA26, U+FAFF, U+FF00..U+FFEF, U+2F800..U+2FA1F, \
+        \
+        \
+        U+0929->U+0928, U+0931->U+0930, U+0934->U+0933, U+0958->U+0915, U+0959->U+0916, \
+        U+095A->U+0917, U+095B->U+091C, U+095C->U+0921, U+095D->U+0922, U+095E->U+092B, \
+        U+095F->U+092F, U+0900..U+097F, \
+        \
+        \
+        U+10FC->U+10DC, U+10D0..U+10FA, U+10A0..U+10C5->U+2D00..U+2D25, U+2D00..U+2D25, \
+        \
+        \
+        U+37a, U+386..U+389->U+3ac..U+3af, U+38c..U+38e->U+3cc..U+3ce, U+390, \
+        U+391..U+3a1->U+3b1..U+3c1, U+3a3..U+3ab->U+3c3..U+3cb, U+3ac..U+3ce, \
+        U+3d0..U+3d7, U+3d8..U+3ef/2, U+3f0..U+3f3, U+3f4->U+3b8, U+3f5, \
+        U+3f7..U+3f8/2, U+3f9->U+3f2, U+3fa..U+3fb/2, U+3fc..U+3ff, \
+        \
+        \
+        U+0A85..U+0A8C, U+0A8F, U+0A90, U+0A93..U+0AB0, U+0AB2, U+0AB3, U+0AB5..U+0AB9, \
+        U+0AE0, U+0AE1, U+0AE6..U+0AEF, \
+        \
+        \
+        U+0C85..U+0C8C, U+0C8E..U+0C90, U+0C92..U+0CA8, U+0CAA..U+0CB3, U+0CB5..U+0CB9, \
+        U+0CE0, U+0CE1, U+0CE6..U+0CEF, \
+        \
+        \
+        U+0D05..U+0D0C, U+0D0E..U+0D10, U+0D12..U+0D28, U+0D2A..U+0D39, U+0D60, U+0D61, \
+        U+0D66..U+0D6F, \
+        \
+        \
+        U+0B94->U+0B92, U+0B85..U+0B8A, U+0B8E..U+0B90, U+0B92, U+0B93, U+0B95, U+0B99, \
+        U+0B9A, U+0B9C, U+0B9E, U+0B9F, U+0BA3, U+0BA4, U+0BA8..U+0BAA, U+0BAE..U+0BB9, \
+        U+0BE6..U+0BEF, \
+        \
+        \
+        U+0E01..U+0E30, U+0E32, U+0E33, U+0E40..U+0E46, U+0E50..U+0E5B
+
+
+  # This section support the CJK charsets
+  # http://sphinxsearch.com/wiki/doku.php?id=charset_tables#cjk_ngram_characters
+  #
+  ngram_len = 1
+  ngram_chars = U+4E00..U+9FBB, U+3400..U+4DB5, U+20000..U+2A6D6, U+FA0E, U+FA0F, U+FA11, \
+        U+FA13, U+FA14, U+FA1F, U+FA21, U+FA23, U+FA24, U+FA27, U+FA28, U+FA29, \
+        U+3105..U+312C, U+31A0..U+31B7, U+3041, U+3043, U+3045, U+3047, U+3049, U+304B, \
+        U+304D, U+304F, U+3051, U+3053, U+3055, U+3057, U+3059, U+305B, U+305D, U+305F, \
+        U+3061, U+3063, U+3066, U+3068, U+306A..U+306F, U+3072, U+3075, U+3078, U+307B, \
+        U+307E..U+3083, U+3085, U+3087, U+3089..U+308E, U+3090..U+3093, U+30A1, U+30A3, \
+        U+30A5, U+30A7, U+30A9, U+30AD, U+30AF, U+30B3, U+30B5, U+30BB, U+30BD, U+30BF, \
+        U+30C1, U+30C3, U+30C4, U+30C6, U+30CA, U+30CB, U+30CD, U+30CE, U+30DE, U+30DF, \
+        U+30E1, U+30E2, U+30E3, U+30E5, U+30E7, U+30EE, U+30F0..U+30F3, U+30F5, U+30F6, \
+        U+31F0, U+31F1, U+31F2, U+31F3, U+31F4, U+31F5, U+31F6, U+31F7, U+31F8, U+31F9, \
+        U+31FA, U+31FB, U+31FC, U+31FD, U+31FE, U+31FF, U+AC00..U+D7A3, U+1100..U+1159, \
+        U+1161..U+11A2, U+11A8..U+11F9, U+A000..U+A48C, U+A492..U+A4C6
+
+
+  # It's necessary to add ignore_chars to ignore vowels, black space and other Arabic signs
+  # http://sphinxsearch.com/wiki/doku.php?id=charset_tables#arabic
+  #
+  ignore_chars = U+0640, U+064B..U+065F,U+06D6..U+06DC,U+06DF..U+06E8,U+06EA..U+06ED
+}
+
 source vanilla_dev_Discussion {
     type = mysql
     sql_host = database
@@ -57,7 +379,7 @@ source vanilla_dev_Discussion_Delta: vanilla_dev_Discussion {
            DiscussionID <= $end
 }
 
-index vanilla_dev_Discussion {
+index vanilla_dev_Discussion: Base_Charsets {
     source = vanilla_dev_Discussion
     path = /usr/local/etc/sphinx/data/Discussion
     morphology = stem_en
@@ -123,7 +445,7 @@ source vanilla_dev_Comment_Delta: vanilla_dev_Comment {
            CommentID <= $end
 }
 
-index vanilla_dev_Comment {
+index vanilla_dev_Comment: Base_Charsets {
     source = vanilla_dev_Comment
     path = /usr/local/etc/sphinx/data/Comment
     morphology = stem_en
@@ -242,7 +564,7 @@ source vanilla_dev_KnowledgeArticle_Delta: vanilla_dev_KnowledgeArticle {
                            AND a.dateUpdated > ar.dateInserted
 }
 
-index vanilla_dev_KnowledgeArticle {
+index vanilla_dev_KnowledgeArticle: Base_Charsets {
     source = vanilla_dev_KnowledgeArticle
     path = /usr/local/etc/sphinx/data/KnowledgeArticle
     morphology = stem_en
@@ -363,7 +685,7 @@ source vanilla_dev_KnowledgeArticleDeleted_Delta: vanilla_dev_KnowledgeArticleDe
                            AND a.dateUpdated > ar.dateInserted
 }
 
-index vanilla_dev_KnowledgeArticleDeleted {
+index vanilla_dev_KnowledgeArticleDeleted: Base_Charsets {
     source = vanilla_dev_KnowledgeArticleDeleted
     path = /usr/local/etc/sphinx/data/KnowledgeArticleDeleted
     morphology = stem_en
@@ -438,7 +760,7 @@ source vanilla_test_Discussion_Delta: vanilla_test_Discussion {
            DiscussionID <= $end
 }
 
-index vanilla_test_Discussion {
+index vanilla_test_Discussion: Base_Charsets {
     source = vanilla_test_Discussion
     path = /usr/local/etc/sphinx/data/DiscussionTest
     morphology = stem_en
@@ -504,7 +826,7 @@ source vanilla_test_Comment_Delta: vanilla_test_Comment {
            CommentID <= $end
 }
 
-index vanilla_test_Comment {
+index vanilla_test_Comment: Base_Charsets {
     source = vanilla_test_Comment
     path = /usr/local/etc/sphinx/data/CommentTest
     morphology = stem_en
@@ -641,7 +963,7 @@ source vanilla_test_KnowledgeArticle_Delta: vanilla_test_KnowledgeArticle {
                         WHERE kb.status = "deleted"
     }
 
-index vanilla_test_KnowledgeArticle {
+index vanilla_test_KnowledgeArticle: Base_Charsets {
     source = vanilla_test_KnowledgeArticle
     path = /usr/local/etc/sphinx/data/KnowledgeArticleTest
     morphology = stem_en
@@ -774,7 +1096,7 @@ source vanilla_test_KnowledgeArticleDeleted_Delta: vanilla_test_KnowledgeArticle
                         WHERE kb.status = "deleted"
 }
 
-index vanilla_test_KnowledgeArticleDeleted {
+index vanilla_test_KnowledgeArticleDeleted: Base_Charsets {
     source = vanilla_test_KnowledgeArticleDeleted
     path = /usr/local/etc/sphinx/data/KnowledgeArticleDeletedTest
     morphology = stem_en
@@ -847,7 +1169,7 @@ source vanilla_dev_Group_Delta: vanilla_dev_Group {
        GroupID <= $end
 }
 
-index vanilla_dev_Group {
+index vanilla_dev_Group: Base_Charsets {
   source = vanilla_dev_Group
   path = /usr/local/etc/sphinx/data/vanilla_dev_Group
   morphology = stem_en
@@ -918,7 +1240,7 @@ source vanilla_test_Group_Delta: vanilla_dev_Group {
        GroupID <= $end
 }
 
-index vanilla_test_Group {
+index vanilla_test_Group: Base_Charsets {
   source = vanilla_dev_Group
   path = /usr/local/etc/sphinx/data/vanilla_test_Group
   morphology = stem_en


### PR DESCRIPTION
## Speed difference

![image](https://user-images.githubusercontent.com/1770056/82736295-955cdb80-9cf6-11ea-8411-af9a5343eb0f.png)

Look at the speed that pages are loaded before after. Pages go from taking 1-2+ seconds to load to <500ms.

## How?

By using [docker-sync](https://github.com/EugenMayer/docker-sync)

[How it works](https://docker-sync.readthedocs.io/en/latest/advanced/how-it-works.html)

**TL;DR;**

It adds a layer between the bind-mount and the actual running code. This means the code runs at full speed by putting the checking of "has this file ben updated" into a separate process from actually reading it.

![image](https://user-images.githubusercontent.com/1770056/82736424-b5d96580-9cf7-11ea-8d9d-4fa5b6006b1a.png)


### How syncing files worked before

- PHP-FPM (or anything) needs to access `SomeFile.php`. It tries to access this through the file-system.
- If the file is mounted from outside docker, docker checks that external system to make sure it has the latest version **SLOW even if there were no changes.**
- Returns the file.

## How it works with docker-sync

- PHP-FPM (or anything) needs to access `SomeFile.php`. It tries to access this through the file-system.
- Native docker/linux file system is used. File is returned immediately.
- ..
- ...
- ....
- In the background the sync continuously watches for file changes and syncs them. This can cause a slight delay (1-2s) while the changes propagate.


## Changes

- Added docker sync.
- Updated the readme.
- Updated the setup script to install all required dependencies if not installed.
  - brew
  - php
  - composer
  - node
  - yarn
  - docker-sync *new*
  - unison *new*
- Moves existing mac-setup script into `bin`
- Add 2 new scripts
  - `start` - Starts all built-in containers and docker-sync.
  - `stop` - Stops all built-in containers and docker-sync.
- Update setup script to make symlinks to for `start` and `stop` into the global `bin`.
  - `vanilla-start` - Start from anywhere.
  - `vanilla-stop` - Stop from anywhere.

## Updating an existing vanilla-docker installation

- Pull this branch (or latest master once this is merged).
- Restart docker entirely.

  ![image](https://user-images.githubusercontent.com/1770056/82736370-4a8f9380-9cf7-11ea-8f18-26f965e9abe1.png)

- Navigate to `vanilla-docker`
- Run `bin/mac-setup` (even if you already ran it before).
- Run `vanilla-start` from anywhere.
- Enjoy your much faster page loads. 🎉🎉🎉🎉🎉🎉🎉

## Caveats

- Initial setup can take a few minutes as the sync is started.
- Updating files (like PHP files) may take 1-2 seconds to reflect in the container.
  - Better to pay a 1-2 second price after making a change than to pay it every single time a page loads.
