### PR TITLE
Update php to 7.4

### DIFF
--- a/images/php-fpm/Dockerfile
+++ b/images/php-fpm/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.3-fpm-stretch
+FROM php:7.4-fpm-buster
 
 RUN set -xe; \
     apt-get update \
@@ -9,6 +9,8 @@ RUN set -xe; \
         libfreetype6-dev \
         libjpeg62-turbo-dev \
         libpng-dev \
+        # for mbstring
+        libonig-dev \
         # memchached extension
         libmemcached-dev \
         # allow mailing to work
@@ -24,7 +26,7 @@ RUN set -xe; \
     && docker-php-ext-enable memcached \
     && docker-php-ext-enable exif \
     # built in extensions install
-    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
+    && docker-php-ext-configure gd --with-freetype --with-jpeg \
     && docker-php-ext-install -j$(nproc) \
         gd \
         mbstring \


### PR DESCRIPTION
Update the container to php 7.4.

- The new Debian release is `buster` instead of `stretch`.
- `libonig-dev` was required otherwise the compilation would fail with:
```
configure: error: Package requirements (oniguruma) were not met:

No package 'oniguruma' found

Consider adjusting the PKG_CONFIG_PATH environment variable if you
installed software in a non-standard prefix.

Alternatively, you may set the environment variables ONIG_CFLAGS
and ONIG_LIBS to avoid the need to call pkg-config.
See the pkg-config man page for more details.
```
- `gd` parameter were updated as per the documentation: https://hub.docker.com/_/php
