### PR TITLE
Increased PHP's max execution time to 10 minutes

### DIFF
--- a/images/php-fpm/usr/local/etc/php/conf.d/00-php.ini
+++ b/images/php-fpm/usr/local/etc/php/conf.d/00-php.ini
@@ -10,3 +10,8 @@ display_errors = on
 upload_max_size = 50M
 post_max_size = 51M
 upload_max_filesize = 50M
+
+; let's have php live longer in local dev (600 sec = 10 min)
+max_execution_time = 600
+
+


### PR DESCRIPTION
This came from a need of longer lasting local jobs on the search project.