### PR TITLE
Update sphinx template to have knowledgeCategoryID = 0 

### DIFF
--- a/resources/usr/local/etc/sphinx/configs-available/everything.sphinx.conf
+++ b/resources/usr/local/etc/sphinx/configs-available/everything.sphinx.conf
@@ -334,6 +334,7 @@ source vanilla_dev_Discussion {
             DiscussionID * 10 + 1, \
             DiscussionID, \
             CategoryID, \
+            0 as knowledgeCategoryID, \
             InsertUserID, \
             unix_timestamp(DateInserted) as DateInserted, \
             Name, \
@@ -347,6 +348,7 @@ source vanilla_dev_Discussion {
             DiscussionID <= $end
     sql_attr_uint = DiscussionID
     sql_attr_uint = CategoryID
+    sql_attr_uint = knowledgeCategoryID
     sql_attr_uint = InsertUserID
     sql_attr_timestamp = DateInserted
     sql_attr_float = Score
@@ -366,6 +368,7 @@ source vanilla_dev_Discussion_Delta: vanilla_dev_Discussion {
             DiscussionID * 10 + 1, \
             DiscussionID, \
             CategoryID, \
+            0 as knowledgeCategoryID, \
             InsertUserID, \
             unix_timestamp(DateInserted) as DateInserted, \
             Name, \
@@ -405,6 +408,7 @@ source vanilla_dev_Comment {
             c.CommentID * 10 + 2, \
             c.DiscussionID, \
             d.CategoryID, \
+            0 as knowledgeCategoryID, \
             c.InsertUserID, \
             unix_timestamp(c.DateInserted) as DateInserted, \
             concat('RE: ', d.Name) as Name, \
@@ -417,6 +421,7 @@ source vanilla_dev_Comment {
             CommentID >= $start AND \
             CommentID <= $end
     sql_attr_uint = CategoryID
+    sql_attr_uint = knowledgeCategoryID
     sql_attr_uint = DiscussionID
     sql_attr_uint = InsertUserID
     sql_attr_timestamp = DateInserted
@@ -432,6 +437,7 @@ source vanilla_dev_Comment_Delta: vanilla_dev_Comment {
             c.CommentID * 10 + 2, \
             c.DiscussionID, \
             d.CategoryID, \
+            0 as knowledgeCategoryID, \
             c.InsertUserID, \
             unix_timestamp(c.DateInserted) as DateInserted, \
             concat('RE: ', d.Name) as Name, \
@@ -715,6 +721,7 @@ source vanilla_test_Discussion {
             DiscussionID * 10 + 1, \
             DiscussionID, \
             CategoryID, \
+            0 as knowledgeCategoryID, \
             InsertUserID, \
             unix_timestamp(DateInserted) as DateInserted, \
             Name, \
@@ -728,6 +735,7 @@ source vanilla_test_Discussion {
             DiscussionID <= $end
     sql_attr_uint = DiscussionID
     sql_attr_uint = CategoryID
+    sql_attr_uint = knowledgeCategoryID
     sql_attr_uint = InsertUserID
     sql_attr_timestamp = DateInserted
     sql_attr_float = Score
@@ -747,6 +755,7 @@ source vanilla_test_Discussion_Delta: vanilla_test_Discussion {
             DiscussionID * 10 + 1, \
             DiscussionID, \
             CategoryID, \
+            0 as knowledgeCategoryID, \
             InsertUserID, \
             unix_timestamp(DateInserted) as DateInserted, \
             Name, \
@@ -786,6 +795,7 @@ source vanilla_test_Comment {
             c.CommentID * 10 + 2, \
             c.DiscussionID, \
             d.CategoryID, \
+            0 as knowledgeCategoryID, \
             c.InsertUserID, \
             unix_timestamp(c.DateInserted) as DateInserted, \
             concat('RE: ', d.Name) as Name, \
@@ -798,6 +808,7 @@ source vanilla_test_Comment {
             CommentID >= $start AND \
             CommentID <= $end
     sql_attr_uint = CategoryID
+    sql_attr_uint = knowledgeCategoryID
     sql_attr_uint = DiscussionID
     sql_attr_uint = InsertUserID
     sql_attr_timestamp = DateInserted
@@ -813,6 +824,7 @@ source vanilla_test_Comment_Delta: vanilla_test_Comment {
             c.CommentID * 10 + 2, \
             c.DiscussionID, \
             d.CategoryID, \
+            0 as knowledgeCategoryID, \
             c.InsertUserID, \
             unix_timestamp(c.DateInserted) as DateInserted, \
             concat('RE: ', d.Name) as Name, \


### PR DESCRIPTION
Update sphinx template to have knowledgeCategoryID = 0 to match some global queries

Relates to: https://github.com/vanilla/vanilla-cloud/issues/403