### PR TITLE
Prevent articles from collapsing into discussions

### DIFF
--- a/resources/usr/local/etc/sphinx/configs-available/everything.sphinx.conf
+++ b/resources/usr/local/etc/sphinx/configs-available/everything.sphinx.conf
@@ -481,7 +481,7 @@ source vanilla_dev_KnowledgeArticle {
     sql_query = SELECT \
             ar.articleRevisionID * 10 + 5, \
             ar.articleRevisionID, \
-            a.articleID as DiscussionID, \
+            a.articleID * 3000000000 + 5 as DiscussionID, \
             ar.locale as locale,\
             kb.knowledgeBaseID as KnowledgeBaseID, \
             kb.siteSectionGroup as siteSectionGroup,\
@@ -540,7 +540,7 @@ source vanilla_dev_KnowledgeArticle_Delta: vanilla_dev_KnowledgeArticle {
     sql_query = SELECT \
                 ar.articleRevisionID * 10 + 5, \
                 ar.articleRevisionID, \
-                a.articleID as DiscussionID, \
+                a.articleID * 3000000000 + 5 as DiscussionID, \
                 ar.locale as locale, \
                 kb.knowledgeBaseID as KnowledgeBaseID, \
                 kb.siteSectionGroup as siteSectionGroup,\
@@ -608,7 +608,7 @@ source vanilla_dev_KnowledgeArticleDeleted {
     sql_query = SELECT \
             ar.articleRevisionID * 10 + 6, \
             ar.articleRevisionID, \
-            a.articleID as DiscussionID, \
+            a.articleID * 3000000000 + 5 as DiscussionID, \
             ar.locale as locale, \
             kb.knowledgeBaseID as KnowledgeBaseID, \
             kb.siteSectionGroup as siteSectionGroup,\
@@ -665,7 +665,7 @@ source vanilla_dev_KnowledgeArticleDeleted_Delta: vanilla_dev_KnowledgeArticleDe
     sql_query = SELECT \
                 ar.articleRevisionID * 10 + 6, \
                 ar.articleRevisionID, \
-                a.articleID as DiscussionID, \
+                a.articleID * 3000000000 + 5 as DiscussionID, \
                 ar.locale as locale, \
                 kb.knowledgeBaseID as KnowledgeBaseID, \
                 kb.siteSectionGroup as siteSectionGroup,\
@@ -881,7 +881,7 @@ source vanilla_test_KnowledgeArticle {
     sql_query = SELECT \
             ar.articleRevisionID * 10 + 5, \
             ar.articleRevisionID, \
-            a.articleID as DiscussionID, \
+            a.articleID * 3000000000 + 5 as DiscussionID, \
             ar.locale as locale, \
             kb.knowledgeBaseID as KnowledgeBaseID, \
             kb.siteSectionGroup as siteSectionGroup,\
@@ -940,7 +940,7 @@ source vanilla_test_KnowledgeArticle_Delta: vanilla_test_KnowledgeArticle {
     sql_query = SELECT \
                 ar.articleRevisionID * 10 + 5, \
                 ar.articleRevisionID, \
-                a.articleID as DiscussionID, \
+                a.articleID * 3000000000 + 5 as DiscussionID, \
                 ar.locale as locale, \
                 kb.knowledgeBaseID as KnowledgeBaseID, \
                 kb.siteSectionGroup as siteSectionGroup,\
@@ -1025,7 +1025,7 @@ source vanilla_test_KnowledgeArticleDeleted {
     sql_query = SELECT \
             ar.articleRevisionID * 10 + 6, \
             ar.articleRevisionID, \
-            a.articleID as DiscussionID, \
+            a.articleID * 3000000000 + 5 as DiscussionID, \
             0 as CategoryID, \
             0 as GroupID, \
             ar.locale as locale, \
@@ -1083,7 +1083,7 @@ source vanilla_test_KnowledgeArticleDeleted_Delta: vanilla_test_KnowledgeArticle
     sql_query = SELECT \
                 ar.articleRevisionID * 10 + 6, \
                 ar.articleRevisionID, \
-                a.articleID as DiscussionID, \
+                a.articleID * 3000000000 + 5 as DiscussionID, \
                 ar.locale as locale, \
                 kb.knowledgeBaseID as KnowledgeBaseID, \
                 kb.siteSectionGroup as siteSectionGroup,\

--- a/resources/usr/local/etc/sphinx/configs-available/everything.sphinx.conf
+++ b/resources/usr/local/etc/sphinx/configs-available/everything.sphinx.conf
@@ -1083,7 +1083,7 @@ source vanilla_test_KnowledgeArticleDeleted_Delta: vanilla_test_KnowledgeArticle
     sql_query = SELECT \
                 ar.articleRevisionID * 10 + 6, \
                 ar.articleRevisionID, \
-                a.articleID * 3000000000 + 5 as DiscussionID, \
+                3000000000 + 5 + a.articleID as DiscussionID, \
                 ar.locale as locale, \
                 kb.knowledgeBaseID as KnowledgeBaseID, \
                 kb.siteSectionGroup as siteSectionGroup,\

--- a/resources/usr/local/etc/sphinx/configs-available/everything.sphinx.conf
+++ b/resources/usr/local/etc/sphinx/configs-available/everything.sphinx.conf
@@ -481,7 +481,7 @@ source vanilla_dev_KnowledgeArticle {
     sql_query = SELECT \
             ar.articleRevisionID * 10 + 5, \
             ar.articleRevisionID, \
-            a.articleID * 3000000000 + 5 as DiscussionID, \
+            4000000000 + 5 + a.articleID as DiscussionID, \
             ar.locale as locale,\
             kb.knowledgeBaseID as KnowledgeBaseID, \
             kb.siteSectionGroup as siteSectionGroup,\
@@ -540,7 +540,7 @@ source vanilla_dev_KnowledgeArticle_Delta: vanilla_dev_KnowledgeArticle {
     sql_query = SELECT \
                 ar.articleRevisionID * 10 + 5, \
                 ar.articleRevisionID, \
-                a.articleID * 3000000000 + 5 as DiscussionID, \
+                4000000000 + 5 + a.articleID as DiscussionID, \
                 ar.locale as locale, \
                 kb.knowledgeBaseID as KnowledgeBaseID, \
                 kb.siteSectionGroup as siteSectionGroup,\
@@ -608,7 +608,7 @@ source vanilla_dev_KnowledgeArticleDeleted {
     sql_query = SELECT \
             ar.articleRevisionID * 10 + 6, \
             ar.articleRevisionID, \
-            a.articleID * 3000000000 + 5 as DiscussionID, \
+            4000000000 + 5 + a.articleID as DiscussionID, \
             ar.locale as locale, \
             kb.knowledgeBaseID as KnowledgeBaseID, \
             kb.siteSectionGroup as siteSectionGroup,\
@@ -665,7 +665,7 @@ source vanilla_dev_KnowledgeArticleDeleted_Delta: vanilla_dev_KnowledgeArticleDe
     sql_query = SELECT \
                 ar.articleRevisionID * 10 + 6, \
                 ar.articleRevisionID, \
-                a.articleID * 3000000000 + 5 as DiscussionID, \
+                4000000000 + 5 + a.articleID as DiscussionID, \
                 ar.locale as locale, \
                 kb.knowledgeBaseID as KnowledgeBaseID, \
                 kb.siteSectionGroup as siteSectionGroup,\
@@ -881,7 +881,7 @@ source vanilla_test_KnowledgeArticle {
     sql_query = SELECT \
             ar.articleRevisionID * 10 + 5, \
             ar.articleRevisionID, \
-            a.articleID * 3000000000 + 5 as DiscussionID, \
+            4000000000 + 5 + a.articleID as DiscussionID, \
             ar.locale as locale, \
             kb.knowledgeBaseID as KnowledgeBaseID, \
             kb.siteSectionGroup as siteSectionGroup,\
@@ -940,7 +940,7 @@ source vanilla_test_KnowledgeArticle_Delta: vanilla_test_KnowledgeArticle {
     sql_query = SELECT \
                 ar.articleRevisionID * 10 + 5, \
                 ar.articleRevisionID, \
-                a.articleID * 3000000000 + 5 as DiscussionID, \
+                4000000000 + 5 + a.articleID as DiscussionID, \
                 ar.locale as locale, \
                 kb.knowledgeBaseID as KnowledgeBaseID, \
                 kb.siteSectionGroup as siteSectionGroup,\
@@ -1025,7 +1025,7 @@ source vanilla_test_KnowledgeArticleDeleted {
     sql_query = SELECT \
             ar.articleRevisionID * 10 + 6, \
             ar.articleRevisionID, \
-            a.articleID * 3000000000 + 5 as DiscussionID, \
+            4000000000 + 5 + a.articleID as DiscussionID, \
             0 as CategoryID, \
             0 as GroupID, \
             ar.locale as locale, \
@@ -1083,7 +1083,7 @@ source vanilla_test_KnowledgeArticleDeleted_Delta: vanilla_test_KnowledgeArticle
     sql_query = SELECT \
                 ar.articleRevisionID * 10 + 6, \
                 ar.articleRevisionID, \
-                3000000000 + 5 + a.articleID as DiscussionID, \
+                4000000000 + 5 + a.articleID as DiscussionID, \
                 ar.locale as locale, \
                 kb.knowledgeBaseID as KnowledgeBaseID, \
                 kb.siteSectionGroup as siteSectionGroup,\


### PR DESCRIPTION
In the same vein as https://github.com/vanilla/vanilla-docker/pull/58, but a reduced set of changes.

Related https://github.com/vanilla/vanilla-cloud/pull/1030

Ensure the discussionIDs of articles are unique. I've made a very similar normalization to what is already on groups in these templates