### PR TITLE
Expose Memcache ports to the host

### DIFF
--- a/service-memcached.yml
+++ b/service-memcached.yml
@@ -29,3 +29,5 @@ services:
         networks:
             - "vanilla_network"
         container_name: memcached
+        ports:
+            - "11211:11211"


### PR DESCRIPTION
I am exposing these ports so that I can use Memcached in tests that run externally. Since this is a dev instance I feel this is a safe and sensible thing to do.