### PR TITLE
Add syslogd

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,16 @@ nginx web server
 
 ### php-fpm
 
-php-fpm with PHP 7.4
+php-fpm with PHP 7.4 and syslogd.
+
+The php-fpm container comes in two flavours, `standard` and `xdebug`.
+The nginx container takes care of routing the request to the appropriate php-fpm flavour based on if your request needs debugging or not.
+
+Both versions integrate `syslogd` to support PHP's `syslog()`. Syslog is tailed to `stdout` and it is prompted by `docker-compose` in the usual way (`docker-compose logs -f`, `docker-compose up --build`, etc)
 
 ### Sphinx
 
-Sphinx search service (service-sphinx.yml). 
+Sphinx search service (service-sphinx.yml).
 
 #### Installing Sphinx
 
@@ -90,7 +95,7 @@ docker exec -t sphinx bash /root/install-sphinx-cron.sh
 *For this setup to work properly you need to clone all vanilla repositories in the same base directory*
 
 1. Get [Docker for OSX](https://download.docker.com/mac/stable/Docker.dmg) and install it.
-    
+
     - Do not forget to tune up the allocated Memory and CPUs. `Docker` > `Preferences` > `Advanced`
 1. Get [Brew, Yarn & Node](https://staff.vanillaforums.com/kb/articles/135-install-node-yarn)
 1. Get [Composer](https://getcomposer.org/) and install it.
@@ -128,7 +133,7 @@ docker exec -t sphinx bash /root/install-sphinx-cron.sh
     ```
     and voila -> [dev.vanilla.localhost](https://dev.vanilla.localhost/) shows the Vanilla installer.
 1. Run the installer!
-    
+
     - It is recommended to use `vanilla_dev` as the database name since some services are configured to use that database.
     - It is recommended to use `database` for the host name.
     - It is recommended to use `root` as the username.
@@ -196,4 +201,3 @@ Q. Why is everything so slow?
 
 A. You are probably running on the APFS file system that became the standard with macOS High Sierra and which has pretty bad performance with Docker for Mac.
 Having the database on your host instead of inside docker might help a lot. See [#10](https://github.com/vanilla/vanilla-docker/issues/10).
-

--- a/README.md
+++ b/README.md
@@ -39,12 +39,12 @@ nginx web server
 
 ### php-fpm
 
-php-fpm with PHP 7.4 and syslogd.
+php-fpm with PHP 7.4 and rsyslogd.
 
 The php-fpm container comes in two flavours, `standard` and `xdebug`.
 The nginx container takes care of routing the request to the appropriate php-fpm flavour based on if your request needs debugging or not.
 
-Both versions integrate `syslogd` to support PHP's `syslog()`. Syslog is tailed to `stdout` and it is prompted by `docker-compose` in the usual way (`docker-compose logs -f`, `docker-compose up --build`, etc)
+Both versions integrate `rsyslogd` to support PHP's `syslog()`. `/var/log/syslog` is tailed to `stdout` and it is prompted by `docker-compose` in the usual way (`docker-compose logs -f`, `docker-compose up --build`, etc)
 
 ### Sphinx
 

--- a/images/php-fpm/Dockerfile
+++ b/images/php-fpm/Dockerfile
@@ -35,7 +35,7 @@ RUN set -xe; \
         pdo_mysql \
         intl \
     # syslogd
-    && apt-get install -y inetutils-syslogd \
+    && apt-get install -y rsyslog \
     # cleanup
     && pecl clear-cache \
     && rm -rf \
@@ -47,6 +47,8 @@ COPY ./conf/00-php.ini /usr/local/etc/php/conf.d/00-php.ini
 COPY ./conf/vanilla-docker-sendmail.ini /usr/local/etc/php/conf.d/vanilla-docker-sendmail.ini
 
 RUN mkdir -p /shared/var/run/
+RUN sed -i '/imklog/s/^/#/' /etc/rsyslog.conf
+RUN touch /var/log/syslog
 
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 

--- a/images/php-fpm/Dockerfile
+++ b/images/php-fpm/Dockerfile
@@ -18,22 +18,24 @@ RUN set -xe; \
         # allow reading of image exif
         exiftool \
         # pecl installs
-        && docker-php-ext-install exif \
-        && pecl install memcached \
-        && pecl install apcu \
-        # enable pecl installed extentions
-        && docker-php-ext-enable memcached \
-        && docker-php-ext-enable apcu \
-        && docker-php-ext-enable exif \
-        && docker-php-ext-enable opcache \
-        # built in extensions install
-        && docker-php-ext-configure gd --with-freetype --with-jpeg \
-        && docker-php-ext-install -j$(nproc) \
+    && docker-php-ext-install exif \
+    && pecl install memcached \
+    && pecl install apcu \
+    # enable pecl installed extentions
+    && docker-php-ext-enable memcached \
+    && docker-php-ext-enable apcu \
+    && docker-php-ext-enable exif \
+    && docker-php-ext-enable opcache \
+    # built in extensions install
+    && docker-php-ext-configure gd --with-freetype --with-jpeg \
+    && docker-php-ext-install -j$(nproc) \
         gd \
         mbstring \
         pdo \
         pdo_mysql \
         intl \
+    # syslogd
+    && apt-get install -y inetutils-syslogd \
     # cleanup
     && pecl clear-cache \
     && rm -rf \

--- a/images/php-fpm/DockerfileXDebug
+++ b/images/php-fpm/DockerfileXDebug
@@ -17,26 +17,28 @@ RUN set -xe; \
         sendmail \
         # allow reading of image exif
         exiftool \
-        # pecl installs
-        && docker-php-ext-install exif \
-        && pecl install xdebug \
-        && pecl install memcached \
-        && pecl install apcu \
-        # enable pecl installed extentions
-        && docker-php-ext-enable xdebug \
-        && docker-php-ext-enable memcached \
-        && docker-php-ext-enable apcu \
-        && docker-php-ext-enable exif \
-        && docker-php-ext-enable opcache \
-        # built in extensions install
-        && docker-php-ext-configure gd --with-freetype --with-jpeg \
-        && docker-php-ext-install -j$(nproc) \
+    # pecl installs
+    && docker-php-ext-install exif \
+    && pecl install xdebug \
+    && pecl install memcached \
+    && pecl install apcu \
+    # enable pecl installed extentions
+    && docker-php-ext-enable xdebug \
+    && docker-php-ext-enable memcached \
+    && docker-php-ext-enable apcu \
+    && docker-php-ext-enable exif \
+    && docker-php-ext-enable opcache \
+    # built in extensions install
+    && docker-php-ext-configure gd --with-freetype --with-jpeg \
+    && docker-php-ext-install -j$(nproc) \
         gd \
         mbstring \
         pdo \
         pdo_mysql \
         intl \
-        # cleanup
+    # syslogd
+    && apt-get install -y inetutils-syslogd \
+    # cleanup
     && pecl clear-cache \
     && rm -rf \
     /var/lib/apt/lists/* \

--- a/images/php-fpm/DockerfileXDebug
+++ b/images/php-fpm/DockerfileXDebug
@@ -37,7 +37,7 @@ RUN set -xe; \
         pdo_mysql \
         intl \
     # syslogd
-    && apt-get install -y inetutils-syslogd \
+    && apt-get install -y rsyslog \
     # cleanup
     && pecl clear-cache \
     && rm -rf \
@@ -50,6 +50,8 @@ COPY ./conf/10-xdebug.ini /usr/local/etc/php/conf.d/10-xdebug.ini
 COPY ./conf/vanilla-docker-sendmail.ini /usr/local/etc/php/conf.d/vanilla-docker-sendmail.ini
 
 RUN mkdir -p /shared/var/run/
+RUN sed -i '/imklog/s/^/#/' /etc/rsyslog.conf
+RUN touch /var/log/syslog
 
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 

--- a/images/php-fpm/docker-entrypoint.sh
+++ b/images/php-fpm/docker-entrypoint.sh
@@ -29,5 +29,9 @@ sendmail -bd
 # Reload certificates so that everything in /usr/local/share/ca-certificates is loaded.
 update-ca-certificates
 
+# Start syslogd
+syslogd
+# Send syslog to docker logs
+tail -f -n0 /var/log/syslog &
 # Start php-fpm
 php-fpm

--- a/images/php-fpm/docker-entrypoint.sh
+++ b/images/php-fpm/docker-entrypoint.sh
@@ -29,8 +29,8 @@ sendmail -bd
 # Reload certificates so that everything in /usr/local/share/ca-certificates is loaded.
 update-ca-certificates
 
-# Start syslogd
-syslogd -m 0
+# Start rsyslogd
+rsyslogd
 # Send syslog to docker logs
 tail -f -n0 /var/log/syslog &
 # Start php-fpm

--- a/images/php-fpm/docker-entrypoint.sh
+++ b/images/php-fpm/docker-entrypoint.sh
@@ -30,7 +30,7 @@ sendmail -bd
 update-ca-certificates
 
 # Start syslogd
-syslogd
+syslogd -m 0
 # Send syslog to docker logs
 tail -f -n0 /var/log/syslog &
 # Start php-fpm


### PR DESCRIPTION
The PR adds `syslogd` to `php-fpm` with a convenient way to check it using `docker-compose logs -f` or `docker-compose up`