### PR TITLE
Fix debug config

### DIFF
--- a/images/php-fpm/conf/10-xdebug.ini
+++ b/images/php-fpm/conf/10-xdebug.ini
@@ -2,9 +2,10 @@ xdebug.idekey = PHPSTORM
 xdebug.profiler_output_dir = /var/log/php-fpm
 
 xdebug.remote_enable = 1
-xdebug.remote_host = 192.0.2.1
 xdebug.profiler_enable_trigger = 1
-
+xdebug.mode = debug
+xdebug.client_host = 192.0.2.1
+xdebug.client_port = 9000
 # Name the profiles with the url.
 xdebug.profiler_output_name = %R.cachegrind.out
 


### PR DESCRIPTION
With the previous configuration Xdebug doesn't work when we start from scratch because the way to setup the remote to xdebug.ini has changed.
@nervoustwit got the same issue 