### PR TITLE
Add locale_int to sphinx templates 

### DIFF
--- a/resources/usr/local/etc/sphinx/configs-available/everything.sphinx.conf
+++ b/resources/usr/local/etc/sphinx/configs-available/everything.sphinx.conf
@@ -340,6 +340,7 @@ source vanilla_dev_Discussion {
             unix_timestamp(DateInserted) as DateInserted, \
             Name, \
             Body, \
+            CRC32('any') as locale_int, \
             field(Type, 'Question', 'Poll', 'Idea') as dtype, \
             inet_aton(InsertIPAddress) as IP, \
             Score \
@@ -356,6 +357,7 @@ source vanilla_dev_Discussion {
     sql_attr_float = Score
     sql_attr_uint = dtype
     sql_attr_uint = IP
+    sql_attr_uint = locale_int
     sql_attr_multi = uint Tags from ranged-query; \
         select DiscussionID * 10 + 1, TagID \
         from GDN_TagDiscussion \
@@ -376,6 +378,7 @@ source vanilla_dev_Discussion_Delta: vanilla_dev_Discussion {
             unix_timestamp(DateInserted) as DateInserted, \
             Name, \
             Body, \
+            CRC32('any') as locale_int, \
             field(Type, 'Question', 'Poll', 'Idea') as dtype, \
             inet_aton(InsertIPAddress) as IP, \
             Score \
@@ -417,6 +420,7 @@ source vanilla_dev_Comment {
             unix_timestamp(c.DateInserted) as DateInserted, \
             concat('RE: ', d.Name) as Name, \
             c.Body, \
+            CRC32('any') as locale_int. \
             inet_aton(c.InsertIPAddress) as IP, \
             field(d.Type, 'Question') + 100 as dtype, \
             c.Score \
@@ -432,6 +436,7 @@ source vanilla_dev_Comment {
     sql_attr_timestamp = DateInserted
     sql_attr_uint = IP
     sql_attr_uint = dtype
+    sql_attr_uint = locale_int
     sql_attr_float = Score
 }
 
@@ -445,6 +450,7 @@ source vanilla_dev_Comment_Delta: vanilla_dev_Comment {
             0 as knowledgeCategoryID, \
             0 as GroupID, \
             c.InsertUserID, \
+            CRC32('any') as locale_int, \
             unix_timestamp(c.DateInserted) as DateInserted, \
             concat('RE: ', d.Name) as Name, \
             c.Body, \
@@ -483,6 +489,7 @@ source vanilla_dev_KnowledgeArticle {
             ar.articleRevisionID, \
             4000000000 + 5 + a.articleID as DiscussionID, \
             ar.locale as locale,\
+            CRC32(ar.locale) as locale_int, \
             kb.knowledgeBaseID as KnowledgeBaseID, \
             kb.siteSectionGroup as siteSectionGroup,\
             0 as CategoryID, \
@@ -529,6 +536,7 @@ source vanilla_dev_KnowledgeArticle {
     sql_attr_uint = status
     sql_attr_string = title
     sql_attr_uint = featured
+    sql_attr_uint = locale_int
     sql_attr_timestamp = dateFeatured
     sql_attr_timestamp = DateInserted
 }
@@ -542,6 +550,7 @@ source vanilla_dev_KnowledgeArticle_Delta: vanilla_dev_KnowledgeArticle {
                 ar.articleRevisionID, \
                 4000000000 + 5 + a.articleID as DiscussionID, \
                 ar.locale as locale, \
+                CRC32(ar.locale) as locale_int, \
                 kb.knowledgeBaseID as KnowledgeBaseID, \
                 kb.siteSectionGroup as siteSectionGroup,\
                 0 as CategoryID, \
@@ -610,6 +619,7 @@ source vanilla_dev_KnowledgeArticleDeleted {
             ar.articleRevisionID, \
             4000000000 + 5 + a.articleID as DiscussionID, \
             ar.locale as locale, \
+            CRC32(ar.locale) as locale_int \
             kb.knowledgeBaseID as KnowledgeBaseID, \
             kb.siteSectionGroup as siteSectionGroup,\
             0 as CategoryID, \
@@ -655,6 +665,7 @@ source vanilla_dev_KnowledgeArticleDeleted {
     sql_attr_uint = status
     sql_attr_string = title
     sql_attr_uint = featured
+    sql_attr_uint = locale_int
     sql_attr_timestamp = dateFeatured
     sql_attr_timestamp = DateInserted
 }
@@ -667,6 +678,7 @@ source vanilla_dev_KnowledgeArticleDeleted_Delta: vanilla_dev_KnowledgeArticleDe
                 ar.articleRevisionID, \
                 4000000000 + 5 + a.articleID as DiscussionID, \
                 ar.locale as locale, \
+                CRC32(ar.locale) as locale_int, \
                 kb.knowledgeBaseID as KnowledgeBaseID, \
                 kb.siteSectionGroup as siteSectionGroup,\
                 0 as CategoryID, \
@@ -736,6 +748,7 @@ source vanilla_test_Discussion {
             0 as knowledgeCategoryID, \
             0 as GroupID, \
             InsertUserID, \
+            CRC32('any') as locale_int, \
             unix_timestamp(DateInserted) as DateInserted, \
             Name, \
             Body, \
@@ -751,6 +764,7 @@ source vanilla_test_Discussion {
     sql_attr_uint = knowledgeCategoryID
     sql_attr_uint = GroupID
     sql_attr_uint = InsertUserID
+    sql_attr_uint = locale_int
     sql_attr_timestamp = DateInserted
     sql_attr_float = Score
     sql_attr_uint = dtype
@@ -772,6 +786,7 @@ source vanilla_test_Discussion_Delta: vanilla_test_Discussion {
             0 as knowledgeCategoryID, \
             0 as GroupID, \
             InsertUserID, \
+            CRC32('any') as locale_int, \
             unix_timestamp(DateInserted) as DateInserted, \
             Name, \
             Body, \
@@ -813,6 +828,7 @@ source vanilla_test_Comment {
             0 as knowledgeCategoryID, \
             0 as GroupID, \
             c.InsertUserID, \
+            CRC32('any') as locale_int, \
             unix_timestamp(c.DateInserted) as DateInserted, \
             concat('RE: ', d.Name) as Name, \
             c.Body, \
@@ -828,6 +844,7 @@ source vanilla_test_Comment {
     sql_attr_uint = GroupID
     sql_attr_uint = DiscussionID
     sql_attr_uint = InsertUserID
+    sql_attr_uint = locale_int
     sql_attr_timestamp = DateInserted
     sql_attr_uint = IP
     sql_attr_uint = dtype
@@ -844,6 +861,7 @@ source vanilla_test_Comment_Delta: vanilla_test_Comment {
             0 as knowledgeCategoryID, \
             0 as GroupID, \
             c.InsertUserID, \
+            CRC32('any') as locale_int, \
             unix_timestamp(c.DateInserted) as DateInserted, \
             concat('RE: ', d.Name) as Name, \
             c.Body, \
@@ -883,6 +901,7 @@ source vanilla_test_KnowledgeArticle {
             ar.articleRevisionID, \
             4000000000 + 5 + a.articleID as DiscussionID, \
             ar.locale as locale, \
+            CRC32(ar.locale) as locale_int, \
             kb.knowledgeBaseID as KnowledgeBaseID, \
             kb.siteSectionGroup as siteSectionGroup,\
             0 as CategoryID, \
@@ -929,6 +948,7 @@ source vanilla_test_KnowledgeArticle {
     sql_attr_uint = status
     sql_attr_string = title
     sql_attr_uint = featured
+    sql_attr_uint = locale_int
     sql_attr_timestamp = dateFeatured
     sql_attr_timestamp = DateInserted
 }
@@ -942,6 +962,7 @@ source vanilla_test_KnowledgeArticle_Delta: vanilla_test_KnowledgeArticle {
                 ar.articleRevisionID, \
                 4000000000 + 5 + a.articleID as DiscussionID, \
                 ar.locale as locale, \
+                CRC32(ar.locale) as locale_int, \
                 kb.knowledgeBaseID as KnowledgeBaseID, \
                 kb.siteSectionGroup as siteSectionGroup,\
                 0 as CategoryID, \
@@ -1029,6 +1050,7 @@ source vanilla_test_KnowledgeArticleDeleted {
             0 as CategoryID, \
             0 as GroupID, \
             ar.locale as locale, \
+            CRC32(ar.locale) as locale_int, \
             kb.knowledgeBaseID as KnowledgeBaseID, \
             kb.siteSectionGroup as siteSectionGroup,\
             a.knowledgeCategoryID, \
@@ -1065,6 +1087,7 @@ source vanilla_test_KnowledgeArticleDeleted {
     sql_attr_uint = insertUserID
     sql_attr_uint = updateUserID
     sql_attr_string = locale
+    sql_attr_uint = locale_int
     sql_attr_string = siteSectionGroup
     sql_attr_uint = dtype
     sql_attr_uint = ip
@@ -1085,6 +1108,7 @@ source vanilla_test_KnowledgeArticleDeleted_Delta: vanilla_test_KnowledgeArticle
                 ar.articleRevisionID, \
                 4000000000 + 5 + a.articleID as DiscussionID, \
                 ar.locale as locale, \
+                CRC32(ar.locale) as locale_int, \
                 kb.knowledgeBaseID as KnowledgeBaseID, \
                 kb.siteSectionGroup as siteSectionGroup,\
                 0 as CategoryID, \
@@ -1165,6 +1189,7 @@ source vanilla_dev_Group {
         0 as CategoryID, \
         0 as knowledgeCategoryID, \
         InsertUserID, \
+        CRC32('any') as locale_int, \
         unix_timestamp(DateInserted) as DateInserted, \
         Name, \
         Description as Body, \
@@ -1180,6 +1205,7 @@ source vanilla_dev_Group {
   sql_attr_uint = CategoryID
   sql_attr_uint = knowledgeCategoryID
   sql_attr_uint = InsertUserID
+  sql_attr_uint = locale_int
   sql_attr_timestamp = DateInserted
   sql_attr_float = Score
   sql_attr_uint = dtype
@@ -1196,6 +1222,7 @@ source vanilla_dev_Group_Delta: vanilla_dev_Group {
        0 as CategoryID, \
        0 as knowledgeCategoryID, \
        InsertUserID, \
+       CRC32('any') as locale_int, \
        unix_timestamp(DateInserted) as DateInserted, \
        Name, \
        Description as Body, \
@@ -1239,6 +1266,7 @@ source vanilla_test_Group {
         0 as CategoryID, \
         0 as knowledgeCategoryID, \
         InsertUserID, \
+        CRC32('any') as locale_int, \
         unix_timestamp(DateInserted) as DateInserted, \
         Name, \
         Description as Body, \
@@ -1254,6 +1282,7 @@ source vanilla_test_Group {
   sql_attr_uint = CategoryID
   sql_attr_uint = knowledgeCategoryID
   sql_attr_uint = InsertUserID
+  sql_attr_uint = locale_int
   sql_attr_timestamp = DateInserted
   sql_attr_float = Score
   sql_attr_uint = dtype
@@ -1270,6 +1299,7 @@ source vanilla_test_Group_Delta: vanilla_dev_Group {
        0 as CategoryID, \
        0 as knowledgeCategoryID, \
        InsertUserID, \
+       CRC32('any') as locale_int, \
        unix_timestamp(DateInserted) as DateInserted, \
        Name, \
        Description as Body, \


### PR DESCRIPTION
Adds new locale_int to fields to sphinx templates.  Because limitations with applying string filters with sphinx, I we chose to hash the locale_int field.  Discussions\Comments\Groups get a value of any, they don't have locales, articles are treated the same using the article revision locale.

related https://github.com/vanilla/vanilla-cloud/pull/2021