### PR TITLE
Update config for Xdebug 3

### DIFF
--- a/images/php-fpm/conf/10-xdebug.ini
+++ b/images/php-fpm/conf/10-xdebug.ini
@@ -1,14 +1,4 @@
-xdebug.idekey = PHPSTORM
-xdebug.profiler_output_dir = /var/log/php-fpm
-
-xdebug.remote_enable = 1
-xdebug.remote_host = 192.0.2.1
-xdebug.profiler_enable_trigger = 1
-
-# Name the profiles with the url.
-xdebug.profiler_output_name = %R.cachegrind.out
-
-; One second only. Fast expiry.
-; Keep requesting the cookie if you want it.
-xdebug.remote_cookie_expire_time = 1
-
+xdebug.idekey=PHPSTORM
+xdebug.mode=debug,develop
+xdebug.start_with_request=yes
+xdebug.client_host=192.0.2.1


### PR DESCRIPTION
Xdebug v3 is now _the_ Xdebug. Trying to build any new images will grab this latest version. Unfortunately, the current Xdebug config bundled here is only for v2. [Many changes were introduced with v3 that need to be accounted for.](https://xdebug.org/docs/upgrade_guide) This PR aims to get everyday step debugging up and running again.

More functionality can be added in the future, as necessary, primarily via [the xdebug.mode config](https://xdebug.org/docs/all_settings#mode).

Closes vanilla/vanilla-cloud#2587