### PR TITLE
Add GZIP to nginx config

### DIFF
--- a/images/nginx/etc/nginx/nginx.conf
+++ b/images/nginx/etc/nginx/nginx.conf
@@ -26,6 +26,19 @@ http {
     ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
     ssl_ciphers ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:ECDH+3DES:DH+3DES:RSA+AESGCM:RSA+AES:RSA+3DES:!aNULL:!MD5:!DSS:!AES256;
 
+
+    gzip on;
+    gzip_disable "msie6";
+
+    gzip_vary on;
+    gzip_proxied any;
+    gzip_comp_level 6;
+    gzip_buffers 16 8k;
+    gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+    # Specify the minimum length of the response to compress (default 20)
+    gzip_min_length 500;
+
+
     sendfile on;
 
     keepalive_timeout 15s;

--- a/images/php-fpm/Dockerfile
+++ b/images/php-fpm/Dockerfile
@@ -46,6 +46,9 @@ COPY ./conf/php-fpm.conf /usr/local/etc/php-fpm.conf
 COPY ./conf/00-php.ini /usr/local/etc/php/conf.d/00-php.ini
 COPY ./conf/vanilla-docker-sendmail.ini /usr/local/etc/php/conf.d/vanilla-docker-sendmail.ini
 
+COPY configure-sendmail.sh /configure-sendmail.sh
+CMD ["/configure-sendmail.sh"]
+
 RUN mkdir -p /shared/var/run/
 RUN sed -i '/imklog/s/^/#/' /etc/rsyslog.conf
 RUN touch /var/log/syslog

--- a/images/php-fpm/DockerfileXDebug
+++ b/images/php-fpm/DockerfileXDebug
@@ -49,6 +49,9 @@ COPY ./conf/00-php.ini /usr/local/etc/php/conf.d/00-php.ini
 COPY ./conf/10-xdebug.ini /usr/local/etc/php/conf.d/10-xdebug.ini
 COPY ./conf/vanilla-docker-sendmail.ini /usr/local/etc/php/conf.d/vanilla-docker-sendmail.ini
 
+COPY configure-sendmail.sh /configure-sendmail.sh
+CMD ["/configure-sendmail.sh"]
+
 RUN mkdir -p /shared/var/run/
 RUN sed -i '/imklog/s/^/#/' /etc/rsyslog.conf
 RUN touch /var/log/syslog

--- a/images/php-fpm/configure-sendmail.sh
+++ b/images/php-fpm/configure-sendmail.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Configure sendmail
+sendmailConfigured=$(grep 'noreply@dev.vanilla.localhost' /etc/hosts)
+if [ -z "$sendmailConfigured" ]; then
+    # add host to /etc/hosts
+    host=$(hostname)
+    line=$(cat /etc/hosts | grep $host)
+    echo "$line noreply@dev.vanilla.localhost" >> /etc/hosts
+
+    echo "$host" >> /etc/mail/relay-domains
+
+    # Make sure that sendmail does not error out if we spoof an email.
+    #
+    # This: www-data set sender to alexandre.c@vanillaforums.com using -f
+    # Would result in an error:
+    # (reason: 553 5.1.8 <alexandre.c@vanillaforums.com>... Domain of sender address alexandre.c@vanillaforums.com does not exist)
+    #
+    lineNumber=$(grep -n -m1 'dnl # Default Mailer setup' /etc/mail/sendmail.mc | cut -d ':' -f1)
+    sed -i "${lineNumber}iFEATURE(\`accept_unresolvable_domains')dnl" /etc/mail/sendmail.mc
+    sed -i "${lineNumber}idnl # Accept unresolvable domains" /etc/mail/sendmail.mc
+
+    m4 /etc/mail/sendmail.mc > /etc/mail/sendmail.cf
+fi
+
+# Start sendmail
+sendmail -bd
+
+# Reload certificates so that everything in /usr/local/share/ca-certificates is loaded.
+update-ca-certificates

--- a/images/php-fpm/docker-entrypoint.sh
+++ b/images/php-fpm/docker-entrypoint.sh
@@ -1,34 +1,5 @@
 #!/bin/bash
 
-# Configure sendmail
-sendmailConfigured=$(grep 'noreply@dev.vanilla.localhost' /etc/hosts)
-if [ -z "$sendmailConfigured" ]; then
-    # add host to /etc/hosts
-    host=$(hostname)
-    line=$(cat /etc/hosts | grep $host)
-    echo "$line noreply@dev.vanilla.localhost" >> /etc/hosts
-
-    echo "$host" >> /etc/mail/relay-domains
-
-    # Make sure that sendmail does not error out if we spoof an email.
-    #
-    # This: www-data set sender to alexandre.c@vanillaforums.com using -f
-    # Would result in an error:
-    # (reason: 553 5.1.8 <alexandre.c@vanillaforums.com>... Domain of sender address alexandre.c@vanillaforums.com does not exist)
-    #
-    lineNumber=$(grep -n -m1 'dnl # Default Mailer setup' /etc/mail/sendmail.mc | cut -d ':' -f1)
-    sed -i "${lineNumber}iFEATURE(\`accept_unresolvable_domains')dnl" /etc/mail/sendmail.mc
-    sed -i "${lineNumber}idnl # Accept unresolvable domains" /etc/mail/sendmail.mc
-
-    m4 /etc/mail/sendmail.mc > /etc/mail/sendmail.cf
-fi
-
-# Start sendmail
-sendmail -bd
-
-# Reload certificates so that everything in /usr/local/share/ca-certificates is loaded.
-update-ca-certificates
-
 # Start rsyslogd
 rsyslogd
 # Send syslog to docker logs


### PR DESCRIPTION
- Add gzip configuration for static assets.
- Update PHP dockerfiles to have sendmail configuration as a separate step. Previously an update to the php config files would invalidate the layer that had sendmail (takes ~1 minute to configure). Now that is cached and the configs happen in a separate layer.