### PR TITLE
Add logging to php container and gzip/http to nginx

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,6 +96,7 @@ services:
         networks: &php-networks
             - "vanilla_network"
         volumes: &php-volumes
+            - "./logs/php-syslog:/var/log:delegated"
             - "./logs/php-fpm:/var/log/php-fpm:delegated"
             - "./resources/certificates:/usr/local/share/ca-certificates:cached" # Mount extra certificates
             - "../:/srv/vanilla-repositories:cached"

--- a/images/nginx/etc/nginx/nginx.conf
+++ b/images/nginx/etc/nginx/nginx.conf
@@ -26,6 +26,17 @@ http {
     ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
     ssl_ciphers ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:ECDH+3DES:DH+3DES:RSA+AESGCM:RSA+AES:RSA+3DES:!aNULL:!MD5:!DSS:!AES256;
 
+    gzip on;
+    gzip_disable "msie6";
+
+    gzip_vary on;
+    gzip_proxied any;
+    gzip_comp_level 6;
+    gzip_buffers 16 8k;
+    gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+    # Specify the minimum length of the response to compress (default 20)
+    gzip_min_length 500;
+
     sendfile on;
 
     keepalive_timeout 15s;

--- a/images/php-fpm/conf/00-php.ini
+++ b/images/php-fpm/conf/00-php.ini
@@ -584,8 +584,7 @@ report_memleaks = On
 ; http://php.net/error-log
 ; Example:
 ;error_log = /var/log/php-fpm/www.error.log
-; Log errors to syslog (Event Log on Windows).
-error_log = syslog
+error_log = /var/log/php-fpm/www.error.log
 
 ; The syslog ident is a string which is prepended to every message logged
 ; to syslog. Only used when error_log is set to syslog.
@@ -605,7 +604,7 @@ error_log = syslog
 ;   all (all characters)
 ;   raw (like "all", but messages are not split at newlines)
 ; http://php.net/syslog.filter
-syslog.filter = ascii
+syslog.filter = all
 
 ;windows.show_crt_warning
 ; Default value: 0

--- a/logs/php-syslog/.gitignore
+++ b/logs/php-syslog/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/resources/etc/nginx/sites-available/dev.vanilla.localhost.conf
+++ b/resources/etc/nginx/sites-available/dev.vanilla.localhost.conf
@@ -2,7 +2,7 @@ server {
     server_name dev.vanilla.localhost;
     listen 80 default_server;
 
-    listen 443 default_server ssl;
+    listen 443 default_server ssl http2;
     ssl_certificate      /certificates/wildcard.vanilla.localhost.crt;
     ssl_certificate_key  /certificates/wildcard.vanilla.localhost.key;
 

--- a/resources/etc/nginx/sites-available/vanilla.localhost.conf
+++ b/resources/etc/nginx/sites-available/vanilla.localhost.conf
@@ -5,7 +5,7 @@ server {
     server_name vanilla.localhost;
     listen 80;
 
-    listen 443 ssl;
+    listen 443 ssl http2;
     ssl_certificate      /certificates/vanilla.localhost.crt;
     ssl_certificate_key  /certificates/vanilla.localhost.key;
 


### PR DESCRIPTION
- Enable gzip and http for the nginx container.
- Add syslog logging and error logging to the php-fpm container.