### PR TITLE
Add try_files for nginx to lookup badly symlinked static asset files

### DIFF
--- a/resources/etc/nginx/sites-available/dev.vanilla.localhost.conf
+++ b/resources/etc/nginx/sites-available/dev.vanilla.localhost.conf
@@ -57,6 +57,11 @@ server {
         fastcgi_pass $xdebug_test_pass;
     }
 
+    # Rewrite for static assets erroneously symlinked into the wrong themes directory.
+    location ~* '^/addons/themes/(?<assetPath>.*)$' {
+        try_files $uri /themes/$assetPath @vanilla;
+    }
+
     # Default location handling
     location / {
         try_files $uri @vanilla;


### PR DESCRIPTION
We have some themes that have historically been symlinked in the wrong place and may have urls pointing to the wrong place if we correct them.

This nginx rule will allow us to make the change without risking any assets previously symlinked in the wrong place from breaking.