### PR TITLE
VNLA-2669: Serve php files for modern sso embed

### DIFF
--- a/resources/etc/nginx/sites-available/modern-embed.vanilla.localhost.conf
+++ b/resources/etc/nginx/sites-available/modern-embed.vanilla.localhost.conf
@@ -21,4 +21,23 @@ server {
     location @htmlext {
         rewrite ^(.*)$ $1.html last;
     }
+
+    location ~* "^/embed-sso\.php(/|$)" {
+        # send to fastcgi
+        include fastcgi.conf;
+        fastcgi_pass $xdebug_test_pass;
+    }
+
+    location ~* "\.php(/|$)" {
+        # send to fastcgi
+        include fastcgi.conf;
+        fastcgi_pass $xdebug_test_pass;
+    }
+
+    location @static {
+        include fastcgi.conf;
+        fastcgi_pass php-fpm;
+        fastcgi_param X_VANILLA 1;
+        rewrite ^ /embed-sso.php?p=$uri last;
+    }
 }

--- a/resources/etc/nginx/sites-available/modern-embed.vanilla.localhost.conf
+++ b/resources/etc/nginx/sites-available/modern-embed.vanilla.localhost.conf
@@ -40,4 +40,9 @@ server {
         fastcgi_param X_VANILLA 1;
         rewrite ^ /embed-sso.php?p=$uri last;
     }
+
+    ## redirect http requests to https ##
+    if ($http_x_forwarded_proto = "http") {
+      return 302 https://$server_name$request_uri;
+    }
 }


### PR DESCRIPTION
### This PR allows the modern embed config to serve a php file needed to dynamically generate SSO strings

Main PR: https://github.com/vanilla/vanilla-cloud/pull/5188