### PR TITLE
Update to use latest PHP 7.4 version

### DIFF
--- a/images/php-fpm/Dockerfile
+++ b/images/php-fpm/Dockerfile
@@ -1,14 +1,6 @@
-FROM php:7.4.6-fpm-alpine
+FROM php:7.4-fpm-alpine
 
-ENV LD_PRELOAD /usr/lib/preloadable_libiconv.so php
-
-RUN apk update \
-    # Make sure we use a version of iconv that works.
-    # https://github.com/docker-library/php/issues/240#issuecomment-876464325
-    && apk add gnu-libiconv=1.15-r3 --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/v3.13/community/ --allow-untrusted \
-    && apk add --no-cache \
-        # build
-        gcc make musl-dev php7-dev \
+RUN apk add --update --no-cache $PHPIZE_DEPS\
         # for intl extension
         icu \
         icu-dev \
@@ -48,9 +40,8 @@ RUN apk update \
         intl \
     # cleanup
     && apk del \
-        gcc make musl-dev php7-dev \
-        icu-dev \
         freetype-dev libjpeg-turbo-dev libpng-dev libwebp-dev libxpm-dev \
+        icu-dev\
         oniguruma-dev \
         libmemcached-dev \
     && pecl clear-cache
@@ -61,5 +52,6 @@ RUN sed -i '/imklog/s/^/#/' /etc/rsyslog.conf
 RUN touch /var/log/syslog
 
 COPY docker-entrypoint.sh /docker-entrypoint.sh
+COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
 CMD ["/docker-entrypoint.sh"]


### PR DESCRIPTION
This PR updates our PHP image to the latest PHP 7.4 version.

- The iconv LD_PRELOAD hack is no longer needed.
- As a result we no longer need php7-dev or musl-dev