### PR TITLE
Fix Xdebug version for php7.4

### DIFF
--- a/images/php-fpm/Dockerfile
+++ b/images/php-fpm/Dockerfile
@@ -18,7 +18,7 @@ RUN apk add --update --no-cache $PHPIZE_DEPS\
     # pecl installs
     && pecl install apcu \
     && pecl install memcached \
-    && pecl install xdebug-2.9.0 \
+    && pecl install xdebug-3.1.0 \
     # enable pecl installed extentions
     && docker-php-ext-enable apcu \
     && docker-php-ext-enable memcached \

--- a/images/php-fpm/Dockerfile
+++ b/images/php-fpm/Dockerfile
@@ -18,7 +18,7 @@ RUN apk add --update --no-cache $PHPIZE_DEPS\
     # pecl installs
     && pecl install apcu \
     && pecl install memcached \
-    && pecl install xdebug \
+    && pecl install xdebug-2.9.0 \
     # enable pecl installed extentions
     && docker-php-ext-enable apcu \
     && docker-php-ext-enable memcached \


### PR DESCRIPTION
This PR will close #125 

Specify the version of 3.1.0 for Xdebug in the PHP Dockerfile so that a) it will run and b) you can continue to debug.